### PR TITLE
feat: add multi-distro support for Fedora/RHEL/AlmaLinux

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -89,12 +89,17 @@ nfpms:
     description: Security-isolated VM environments for AI coding agents
     formats:
       - deb
+      - rpm
     bindir: /usr/bin
     contents:
       - src: completions/abox.bash
         dst: /usr/share/bash-completion/completions/abox
       - src: completions/_abox
         dst: /usr/share/zsh/vendor-completions/_abox
+        packager: deb
+      - src: completions/_abox
+        dst: /usr/share/zsh/site-functions/_abox
+        packager: rpm
       - src: completions/abox.fish
         dst: /usr/share/fish/vendor_completions.d/abox.fish
       - src: manpages/abox*.1.gz

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -9,6 +9,7 @@ Abox is tested on:
 - **Ubuntu 22.04+** (LTS recommended)
 - **Debian 13+** (Trixie and newer)
 - **Fedora 38+**
+- **AlmaLinux 9+, Rocky Linux 9+, CentOS Stream 9+** (RHEL family; requires [EPEL](https://docs.fedoraproject.org/en-US/epel/) for `fuse-sshfs`)
 - **Arch Linux** (rolling release)
 
 Other Linux distributions with libvirt 8.0+ and QEMU 6.0+ should work.
@@ -34,9 +35,9 @@ Other Linux distributions with libvirt 8.0+ and QEMU 6.0+ should work.
 | iptables | Yes | iptables | iptables | DNS redirect rules |
 | pkexec | Yes* | policykit-1 | polkit | Privilege escalation |
 | sudo | Yes* | sudo | sudo | Privilege escalation (fallback) |
-| sshfs | Yes | sshfs | sshfs | Mount command |
+| sshfs | Yes | sshfs | fuse-sshfs (EPEL on RHEL) | Mount command |
 | fusermount | Yes | fuse3 | fuse3 | Unmount command |
-| genisoimage | Yes** | genisoimage | cdrkit | Cloud-init ISO creation |
+| genisoimage | Yes** | genisoimage | genisoimage (EPEL on RHEL) | Cloud-init ISO creation |
 | xorriso | Yes** | xorriso | xorriso | Cloud-init ISO creation |
 | tcpdump | No | tcpdump | tcpdump | Packet capture (tap command) |
 
@@ -108,7 +109,7 @@ sudo dnf install \
   qemu-img \
   openssh-clients \
   iptables \
-  sshfs \
+  fuse-sshfs \
   fuse3 \
   genisoimage
 
@@ -118,6 +119,37 @@ sudo usermod -aG libvirt $USER
 # Start libvirtd
 sudo systemctl enable --now libvirtd
 ```
+
+### RHEL / AlmaLinux / Rocky / CentOS Stream
+
+On the RHEL family, `fuse-sshfs` (and `genisoimage`) ship in EPEL, not the base
+repos, so enable EPEL first:
+
+```bash
+# Enable EPEL (provides fuse-sshfs, genisoimage)
+sudo dnf install -y epel-release
+
+# Required packages
+sudo dnf install \
+  libvirt \
+  libvirt-client \
+  qemu-kvm \
+  qemu-img \
+  openssh-clients \
+  iptables \
+  fuse-sshfs \
+  fuse3 \
+  xorriso
+
+# Add user to libvirt group
+sudo usermod -aG libvirt $USER
+
+# Start libvirtd
+sudo systemctl enable --now libvirtd
+```
+
+If `firewalld` is active, see [Firewall Configuration](#firewall-configuration)
+below — abox's iptables NAT rules can conflict with it.
 
 ### Arch Linux
 

--- a/internal/libvirt/templates/domain.xml.tmpl
+++ b/internal/libvirt/templates/domain.xml.tmpl
@@ -29,7 +29,6 @@
   </clock>
   <on_crash>destroy</on_crash>
   <devices>
-    <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2' cache='none' io='native'
               discard='unmap' detect_zeroes='unmap' iothread='1'/>

--- a/internal/privilege/privilege.go
+++ b/internal/privilege/privilege.go
@@ -14,15 +14,25 @@ import (
 	"github.com/sandialabs/abox/internal/errhint"
 )
 
+// qemuDiskGroups lists the groups used by QEMU to access disk images.
+// The name varies by distribution: libvirt-qemu (Debian/Ubuntu), qemu (Fedora),
+// or kvm.
+var qemuDiskGroups = []string{"libvirt-qemu", "qemu", "kvm"}
+
 // InLibvirtGroup checks if the current user is in the libvirt group.
 func InLibvirtGroup() bool {
 	return InGroup("libvirt")
 }
 
-// InLibvirtQemuGroup checks if the current user is in the libvirt-qemu or kvm group.
-// These groups are used by QEMU processes to access disk images.
+// InLibvirtQemuGroup checks if the current user is in a QEMU disk access group.
+// Returns true if the user is in any of the known QEMU disk access groups.
 func InLibvirtQemuGroup() bool {
-	return InGroup("libvirt-qemu") || InGroup("kvm")
+	for _, g := range qemuDiskGroups {
+		if InGroup(g) {
+			return true
+		}
+	}
+	return false
 }
 
 // InGroup checks if the current process is in the specified group.
@@ -74,8 +84,16 @@ func CanAccessLibvirtImages() error {
 	// Check write access
 	if err := unix.Access(checkDir, unix.W_OK); err != nil {
 		// Provide remediation suggestions
+		// Detect which QEMU disk group exists on this system for the hint message.
+		qemuGroup := qemuDiskGroups[0]
+		for _, g := range qemuDiskGroups {
+			if _, err := user.LookupGroup(g); err == nil {
+				qemuGroup = g
+				break
+			}
+		}
 		suggestions := []string{
-			"Add user to libvirt-qemu group: sudo usermod -aG libvirt-qemu " + os.Getenv("USER"),
+			"Add user to " + qemuGroup + " group: sudo usermod -aG " + qemuGroup + " " + os.Getenv("USER"),
 			"Or set ACLs: sudo setfacl -m u:" + os.Getenv("USER") + ":rwx " + imagesDir,
 		}
 		return &errhint.ErrHint{

--- a/internal/privilege/privilege.go
+++ b/internal/privilege/privilege.go
@@ -27,12 +27,7 @@ func InLibvirtGroup() bool {
 // InLibvirtQemuGroup checks if the current user is in a QEMU disk access group.
 // Returns true if the user is in any of the known QEMU disk access groups.
 func InLibvirtQemuGroup() bool {
-	for _, g := range qemuDiskGroups {
-		if InGroup(g) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(qemuDiskGroups, InGroup)
 }
 
 // InGroup checks if the current process is in the specified group.

--- a/pkg/cmd/checkdeps/checkdeps.go
+++ b/pkg/cmd/checkdeps/checkdeps.go
@@ -105,6 +105,7 @@ func runCheckDeps(opts *Options) error {
 	}
 
 	if !opts.Quiet {
+		warnFirewalld(w)
 		fmt.Fprintln(w, "All required dependencies are installed.")
 	}
 
@@ -154,7 +155,7 @@ func validateToolPairs(w io.Writer, quiet bool) error {
 			return &cmdutil.ErrSilent{}
 		}
 		fmt.Fprintln(w, "Error: no ISO creation tool available (need genisoimage or xorriso)")
-		fmt.Fprintln(w, "  Install: apt install genisoimage  (or: apt install xorriso)")
+		fmt.Fprintf(w, "  Install: %s  (or: %s)\n", installHint("genisoimage"), installHint("xorriso"))
 		return errors.New("no ISO creation tool available")
 	}
 	return nil
@@ -174,9 +175,9 @@ func validateLibvirtAccess(w io.Writer, quiet bool) error {
 	if !quiet {
 		fmt.Fprintln(w, "  libvirt group: member")
 		if privilege.InLibvirtQemuGroup() {
-			fmt.Fprintln(w, "  libvirt-qemu/kvm group: member")
+			fmt.Fprintln(w, "  qemu disk access group: member")
 		} else {
-			fmt.Fprintln(w, "  libvirt-qemu/kvm group: not a member")
+			fmt.Fprintln(w, "  qemu disk access group: not a member")
 		}
 		if err := privilege.CanAccessLibvirtImages(); err != nil {
 			fmt.Fprintf(w, "  libvirt images access: %v\n", err)
@@ -224,6 +225,25 @@ func installHint(name string) string {
 		return hint
 	}
 	return "check your package manager"
+}
+
+// warnFirewalld prints a warning if firewalld is active, since it can
+// interfere with the iptables NAT rules abox creates for DNS redirection.
+func warnFirewalld(w io.Writer) {
+	path, err := exec.LookPath("firewall-cmd")
+	if err != nil {
+		return
+	}
+	cmd := exec.Command(path, "--state")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return // not running
+	}
+	fmt.Fprintln(w, "  Warning: firewalld is active")
+	fmt.Fprintln(w, "  abox uses iptables NAT rules that may conflict with firewalld.")
+	fmt.Fprintln(w, "  See 'abox docs requirements' or docs/requirements.md for firewalld setup.")
+	fmt.Fprintln(w)
 }
 
 // RunQuiet runs dependency checks without output, returns true if all pass.

--- a/pkg/cmd/checkdeps/checkdeps.go
+++ b/pkg/cmd/checkdeps/checkdeps.go
@@ -22,11 +22,15 @@ type dependency struct {
 	name     string
 	required bool
 	usedBy   string
+	hint     string // install instructions; empty falls back to a generic message
 }
 
-// External command names, referenced from the dependency table, the
-// installHint map, and the validation logic. Named constants keep these in
-// sync — a mismatch between any two would otherwise be a silent bug.
+// hintOpenSSH is shared by the OpenSSH client tools (ssh, scp, ssh-keygen).
+const hintOpenSSH = "install openssh-client (Debian/Ubuntu) or openssh-clients (Fedora/RHEL)"
+
+// External command names, referenced from the dependency table and the
+// validation logic. Named constants keep these in sync — a mismatch between
+// any two would otherwise be a silent bug.
 const (
 	depVirsh       = "virsh"
 	depQemuImg     = "qemu-img"
@@ -44,19 +48,87 @@ const (
 )
 
 var dependencies = []dependency{
-	{name: depVirsh, required: true, usedBy: "all VM/network operations"},
-	{name: depQemuImg, required: true, usedBy: "create, base pull"},
-	{name: depSSH, required: true, usedBy: "ssh, provision, scp"},
-	{name: depSCP, required: true, usedBy: "scp command"},
-	{name: depSSHFS, required: true, usedBy: "mount command"},
-	{name: depSSHKeygen, required: true, usedBy: "create (key generation)"},
-	{name: depGenisoimage, required: false, usedBy: "create (cloud-init ISO, required if xorriso not installed)"},
-	{name: depXorriso, required: false, usedBy: "create (cloud-init ISO, required if genisoimage not installed)"},
-	{name: depPkexec, required: false, usedBy: "iptables rules (preferred)"},
-	{name: depSudo, required: false, usedBy: "iptables rules (fallback)"},
-	{name: depIptables, required: true, usedBy: "DNS redirect"},
-	{name: depFusermount, required: true, usedBy: "unmount command"},
-	{name: depTCPdump, required: false, usedBy: "tap (packet capture)"},
+	{
+		name:     depVirsh,
+		required: true,
+		usedBy:   "all VM/network operations",
+		hint:     "install libvirt-clients (Debian/Ubuntu) or libvirt-client (Fedora/RHEL/Arch)",
+	},
+	{
+		name:     depQemuImg,
+		required: true,
+		usedBy:   "create, base pull",
+		hint:     "install qemu-utils (Debian/Ubuntu) or qemu-img (Fedora/RHEL/Arch)",
+	},
+	{
+		name:     depSSH,
+		required: true,
+		usedBy:   "ssh, provision, scp",
+		hint:     hintOpenSSH,
+	},
+	{
+		name:     depSCP,
+		required: true,
+		usedBy:   "scp command",
+		hint:     hintOpenSSH,
+	},
+	{
+		name:     depSSHFS,
+		required: true,
+		usedBy:   "mount command",
+		// On Fedora/RHEL the package is fuse-sshfs, and on RHEL/AlmaLinux/Rocky it
+		// lives in EPEL rather than the base repos.
+		hint: "install sshfs (Debian/Ubuntu) or fuse-sshfs (Fedora; needs EPEL on RHEL/AlmaLinux/Rocky)",
+	},
+	{
+		name:     depSSHKeygen,
+		required: true,
+		usedBy:   "create (key generation)",
+		hint:     hintOpenSSH,
+	},
+	{
+		name:     depGenisoimage,
+		required: false,
+		usedBy:   "create (cloud-init ISO, required if xorriso not installed)",
+		// genisoimage is EPEL-only on RHEL; xorriso is in the base repos everywhere,
+		// so prefer it when EPEL is unavailable.
+		hint: "install genisoimage (Debian/Ubuntu/Fedora; EPEL on RHEL) or install xorriso instead",
+	},
+	{
+		name:     depXorriso,
+		required: false,
+		usedBy:   "create (cloud-init ISO, required if genisoimage not installed)",
+		hint:     "install xorriso",
+	},
+	{
+		name:     depPkexec,
+		required: false,
+		usedBy:   "iptables rules (preferred)",
+		hint:     "install polkit (usually pre-installed)",
+	},
+	{
+		name:     depSudo,
+		required: false,
+		usedBy:   "iptables rules (fallback)",
+		hint:     "install sudo",
+	},
+	{
+		name:     depIptables,
+		required: true,
+		usedBy:   "DNS redirect",
+		hint:     "install iptables",
+	},
+	{
+		name:     depFusermount,
+		required: true,
+		usedBy:   "unmount command",
+		hint:     "install fuse or fuse3",
+	},
+	{
+		name:     depTCPdump,
+		required: false,
+		usedBy:   "tap (packet capture)",
+	},
 }
 
 // Options holds the options for the check-deps command.
@@ -225,27 +297,10 @@ func checkExecutable(name string) error {
 }
 
 func installHint(name string) string {
-	const hintOpenSSH = "install openssh-client (Debian/Ubuntu) or openssh-clients (Fedora/RHEL)"
-	hints := map[string]string{
-		depVirsh:   "install libvirt-clients (Debian/Ubuntu) or libvirt-client (Fedora/RHEL/Arch)",
-		depQemuImg: "install qemu-utils (Debian/Ubuntu) or qemu-img (Fedora/RHEL/Arch)",
-		depSSH:     hintOpenSSH,
-		depSCP:     hintOpenSSH,
-		// On Fedora/RHEL the package is fuse-sshfs, and on RHEL/AlmaLinux/Rocky it
-		// lives in EPEL rather than the base repos.
-		depSSHFS:     "install sshfs (Debian/Ubuntu) or fuse-sshfs (Fedora; needs EPEL on RHEL/AlmaLinux/Rocky)",
-		depSSHKeygen: hintOpenSSH,
-		// genisoimage is EPEL-only on RHEL; xorriso is in the base repos everywhere,
-		// so prefer it when EPEL is unavailable.
-		depGenisoimage: "install genisoimage (Debian/Ubuntu/Fedora; EPEL on RHEL) or install xorriso instead",
-		depXorriso:     "install xorriso",
-		depPkexec:      "install polkit (usually pre-installed)",
-		depSudo:        "install sudo",
-		depIptables:    "install iptables",
-		depFusermount:  "install fuse or fuse3",
-	}
-	if hint, ok := hints[name]; ok {
-		return hint
+	for _, dep := range dependencies {
+		if dep.name == name && dep.hint != "" {
+			return dep.hint
+		}
 	}
 	return "check your package manager"
 }

--- a/pkg/cmd/checkdeps/checkdeps.go
+++ b/pkg/cmd/checkdeps/checkdeps.go
@@ -206,15 +206,19 @@ func checkExecutable(name string) error {
 }
 
 func installHint(name string) string {
-	const hintOpenSSHClient = "install openssh-client"
+	const hintOpenSSH = "install openssh-client (Debian/Ubuntu) or openssh-clients (Fedora/RHEL)"
 	hints := map[string]string{
-		"virsh":       "install libvirt-clients (Debian/Ubuntu) or libvirt (Fedora/Arch)",
-		"qemu-img":    "install qemu-utils (Debian/Ubuntu) or qemu-img (Fedora/Arch)",
-		"ssh":         hintOpenSSHClient,
-		"scp":         hintOpenSSHClient,
-		"sshfs":       "install sshfs",
-		"ssh-keygen":  hintOpenSSHClient,
-		"genisoimage": "install genisoimage (Debian/Ubuntu) or cdrkit (Fedora/Arch)",
+		"virsh":    "install libvirt-clients (Debian/Ubuntu) or libvirt-client (Fedora/RHEL/Arch)",
+		"qemu-img": "install qemu-utils (Debian/Ubuntu) or qemu-img (Fedora/RHEL/Arch)",
+		"ssh":      hintOpenSSH,
+		"scp":      hintOpenSSH,
+		// On Fedora/RHEL the package is fuse-sshfs, and on RHEL/AlmaLinux/Rocky it
+		// lives in EPEL rather than the base repos.
+		"sshfs":      "install sshfs (Debian/Ubuntu) or fuse-sshfs (Fedora; needs EPEL on RHEL/AlmaLinux/Rocky)",
+		"ssh-keygen": hintOpenSSH,
+		// genisoimage is EPEL-only on RHEL; xorriso is in the base repos everywhere,
+		// so prefer it when EPEL is unavailable.
+		"genisoimage": "install genisoimage (Debian/Ubuntu/Fedora; EPEL on RHEL) or install xorriso instead",
 		"xorriso":     "install xorriso",
 		"pkexec":      "install polkit (usually pre-installed)",
 		"sudo":        "install sudo",

--- a/pkg/cmd/checkdeps/checkdeps.go
+++ b/pkg/cmd/checkdeps/checkdeps.go
@@ -24,20 +24,39 @@ type dependency struct {
 	usedBy   string
 }
 
+// External command names, referenced from the dependency table, the
+// installHint map, and the validation logic. Named constants keep these in
+// sync — a mismatch between any two would otherwise be a silent bug.
+const (
+	depVirsh       = "virsh"
+	depQemuImg     = "qemu-img"
+	depSSH         = "ssh"
+	depSCP         = "scp"
+	depSSHFS       = "sshfs"
+	depSSHKeygen   = "ssh-keygen"
+	depGenisoimage = "genisoimage"
+	depXorriso     = "xorriso"
+	depPkexec      = "pkexec"
+	depSudo        = "sudo"
+	depIptables    = "iptables"
+	depFusermount  = "fusermount"
+	depTCPdump     = "tcpdump"
+)
+
 var dependencies = []dependency{
-	{name: "virsh", required: true, usedBy: "all VM/network operations"},
-	{name: "qemu-img", required: true, usedBy: "create, base pull"},
-	{name: "ssh", required: true, usedBy: "ssh, provision, scp"},
-	{name: "scp", required: true, usedBy: "scp command"},
-	{name: "sshfs", required: true, usedBy: "mount command"},
-	{name: "ssh-keygen", required: true, usedBy: "create (key generation)"},
-	{name: "genisoimage", required: false, usedBy: "create (cloud-init ISO, required if xorriso not installed)"},
-	{name: "xorriso", required: false, usedBy: "create (cloud-init ISO, required if genisoimage not installed)"},
-	{name: "pkexec", required: false, usedBy: "iptables rules (preferred)"},
-	{name: "sudo", required: false, usedBy: "iptables rules (fallback)"},
-	{name: "iptables", required: true, usedBy: "DNS redirect"},
-	{name: "fusermount", required: true, usedBy: "unmount command"},
-	{name: "tcpdump", required: false, usedBy: "tap (packet capture)"},
+	{name: depVirsh, required: true, usedBy: "all VM/network operations"},
+	{name: depQemuImg, required: true, usedBy: "create, base pull"},
+	{name: depSSH, required: true, usedBy: "ssh, provision, scp"},
+	{name: depSCP, required: true, usedBy: "scp command"},
+	{name: depSSHFS, required: true, usedBy: "mount command"},
+	{name: depSSHKeygen, required: true, usedBy: "create (key generation)"},
+	{name: depGenisoimage, required: false, usedBy: "create (cloud-init ISO, required if xorriso not installed)"},
+	{name: depXorriso, required: false, usedBy: "create (cloud-init ISO, required if genisoimage not installed)"},
+	{name: depPkexec, required: false, usedBy: "iptables rules (preferred)"},
+	{name: depSudo, required: false, usedBy: "iptables rules (fallback)"},
+	{name: depIptables, required: true, usedBy: "DNS redirect"},
+	{name: depFusermount, required: true, usedBy: "unmount command"},
+	{name: depTCPdump, required: false, usedBy: "tap (packet capture)"},
 }
 
 // Options holds the options for the check-deps command.
@@ -141,7 +160,7 @@ func checkAllDependencies(w io.Writer, quiet bool) []string {
 
 func validateToolPairs(w io.Writer, quiet bool) error {
 	// Check that at least one privilege escalation method is available
-	if checkExecutable("pkexec") != nil && checkExecutable("sudo") != nil {
+	if checkExecutable(depPkexec) != nil && checkExecutable(depSudo) != nil {
 		if quiet {
 			return &cmdutil.ErrSilent{}
 		}
@@ -150,12 +169,12 @@ func validateToolPairs(w io.Writer, quiet bool) error {
 	}
 
 	// Check that at least one ISO creation tool is available
-	if checkExecutable("genisoimage") != nil && checkExecutable("xorriso") != nil {
+	if checkExecutable(depGenisoimage) != nil && checkExecutable(depXorriso) != nil {
 		if quiet {
 			return &cmdutil.ErrSilent{}
 		}
 		fmt.Fprintln(w, "Error: no ISO creation tool available (need genisoimage or xorriso)")
-		fmt.Fprintf(w, "  Install: %s  (or: %s)\n", installHint("genisoimage"), installHint("xorriso"))
+		fmt.Fprintf(w, "  Install: %s  (or: %s)\n", installHint(depGenisoimage), installHint(depXorriso))
 		return errors.New("no ISO creation tool available")
 	}
 	return nil
@@ -208,22 +227,22 @@ func checkExecutable(name string) error {
 func installHint(name string) string {
 	const hintOpenSSH = "install openssh-client (Debian/Ubuntu) or openssh-clients (Fedora/RHEL)"
 	hints := map[string]string{
-		"virsh":    "install libvirt-clients (Debian/Ubuntu) or libvirt-client (Fedora/RHEL/Arch)",
-		"qemu-img": "install qemu-utils (Debian/Ubuntu) or qemu-img (Fedora/RHEL/Arch)",
-		"ssh":      hintOpenSSH,
-		"scp":      hintOpenSSH,
+		depVirsh:   "install libvirt-clients (Debian/Ubuntu) or libvirt-client (Fedora/RHEL/Arch)",
+		depQemuImg: "install qemu-utils (Debian/Ubuntu) or qemu-img (Fedora/RHEL/Arch)",
+		depSSH:     hintOpenSSH,
+		depSCP:     hintOpenSSH,
 		// On Fedora/RHEL the package is fuse-sshfs, and on RHEL/AlmaLinux/Rocky it
 		// lives in EPEL rather than the base repos.
-		"sshfs":      "install sshfs (Debian/Ubuntu) or fuse-sshfs (Fedora; needs EPEL on RHEL/AlmaLinux/Rocky)",
-		"ssh-keygen": hintOpenSSH,
+		depSSHFS:     "install sshfs (Debian/Ubuntu) or fuse-sshfs (Fedora; needs EPEL on RHEL/AlmaLinux/Rocky)",
+		depSSHKeygen: hintOpenSSH,
 		// genisoimage is EPEL-only on RHEL; xorriso is in the base repos everywhere,
 		// so prefer it when EPEL is unavailable.
-		"genisoimage": "install genisoimage (Debian/Ubuntu/Fedora; EPEL on RHEL) or install xorriso instead",
-		"xorriso":     "install xorriso",
-		"pkexec":      "install polkit (usually pre-installed)",
-		"sudo":        "install sudo",
-		"iptables":    "install iptables",
-		"fusermount":  "install fuse or fuse3",
+		depGenisoimage: "install genisoimage (Debian/Ubuntu/Fedora; EPEL on RHEL) or install xorriso instead",
+		depXorriso:     "install xorriso",
+		depPkexec:      "install polkit (usually pre-installed)",
+		depSudo:        "install sudo",
+		depIptables:    "install iptables",
+		depFusermount:  "install fuse or fuse3",
 	}
 	if hint, ok := hints[name]; ok {
 		return hint
@@ -262,15 +281,15 @@ func RunQuiet() bool {
 	}
 
 	// Check that at least one privilege escalation method is available
-	pkexecErr := checkExecutable("pkexec")
-	sudoErr := checkExecutable("sudo")
+	pkexecErr := checkExecutable(depPkexec)
+	sudoErr := checkExecutable(depSudo)
 	if pkexecErr != nil && sudoErr != nil {
 		return false
 	}
 
 	// Check that at least one ISO creation tool is available
-	genisoimageErr := checkExecutable("genisoimage")
-	xorrisoErr := checkExecutable("xorriso")
+	genisoimageErr := checkExecutable(depGenisoimage)
+	xorrisoErr := checkExecutable(depXorriso)
 	if genisoimageErr != nil && xorrisoErr != nil {
 		return false
 	}

--- a/pkg/cmd/checkdeps/checkdeps_test.go
+++ b/pkg/cmd/checkdeps/checkdeps_test.go
@@ -1,0 +1,41 @@
+package checkdeps
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestInstallHint verifies the install hints name the correct package per distro
+// family. These caught real gaps for the RHEL/Fedora family (the package is
+// fuse-sshfs, openssh-clients, and several deps live in EPEL), so guard them.
+func TestInstallHint(t *testing.T) {
+	cases := []struct {
+		name        string
+		mustContain []string
+	}{
+		{"sshfs", []string{"sshfs", "fuse-sshfs", "EPEL"}},
+		{"ssh", []string{"openssh-client", "openssh-clients"}},
+		{"scp", []string{"openssh-client", "openssh-clients"}},
+		{"ssh-keygen", []string{"openssh-client", "openssh-clients"}},
+		{"genisoimage", []string{"genisoimage", "EPEL", "xorriso"}},
+		{"virsh", []string{"libvirt-clients", "libvirt-client"}},
+		{"qemu-img", []string{"qemu-utils", "qemu-img"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := installHint(tc.name)
+			for _, want := range tc.mustContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("installHint(%q) = %q; want it to contain %q", tc.name, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestInstallHintUnknown falls back to a generic message for unknown tools.
+func TestInstallHintUnknown(t *testing.T) {
+	if got := installHint("totally-unknown-tool"); got != "check your package manager" {
+		t.Errorf("installHint(unknown) = %q; want generic fallback", got)
+	}
+}

--- a/pkg/cmd/doctor/doctor.go
+++ b/pkg/cmd/doctor/doctor.go
@@ -643,28 +643,48 @@ func checkProxyEnvVars(paths *config.Paths, user, ip, gateway string, httpPort i
 	return result
 }
 
-// checkDNSConfig verifies systemd-resolved is configured correctly in the guest.
+// checkDNSConfig verifies DNS is configured correctly in the guest.
+// Supports systemd-resolved (Debian/Ubuntu), NetworkManager (RHEL/AlmaLinux),
+// and direct resolv.conf configuration.
 func checkDNSConfig(paths *config.Paths, user, ip, gateway string) CheckResult {
 	result := CheckResult{Name: CheckNameDNSConfig}
 
-	// Check if the abox DNS config file exists
+	// Try systemd-resolved config (Debian/Ubuntu)
 	output, err := runSSHCommandOutput(paths, user, ip, "cat", "/etc/systemd/resolved.conf.d/00-abox.conf")
-	if err != nil {
+	if err == nil {
+		if strings.Contains(string(output), gateway) {
+			result.Passed = true
+			result.Details = "DNS=" + gateway + " (systemd-resolved)"
+			return result
+		}
 		result.Passed = false
-		result.Details = "abox DNS config not found"
-		result.Hint = hintCheckCloudInit
-		return result
-	}
-
-	content := string(output)
-	if !strings.Contains(content, gateway) {
-		result.Passed = false
-		result.Details = "DNS config doesn't point to gateway"
+		result.Details = "systemd-resolved config doesn't point to gateway"
 		result.Hint = "systemd-resolved may not use the abox DNS filter"
 		return result
 	}
 
-	result.Passed = true
-	result.Details = "DNS=" + gateway
+	// Try NetworkManager config (RHEL/AlmaLinux/Rocky)
+	output, err = runSSHCommandOutput(paths, user, ip, "cat", "/etc/NetworkManager/conf.d/99-abox-dns.conf")
+	if err == nil && strings.Contains(string(output), "dns=none") {
+		// NetworkManager DNS is disabled; check resolv.conf directly
+		output, err = runSSHCommandOutput(paths, user, ip, "cat", "/etc/resolv.conf")
+		if err == nil && strings.Contains(string(output), gateway) {
+			result.Passed = true
+			result.Details = "DNS=" + gateway + " (NetworkManager/resolv.conf)"
+			return result
+		}
+	}
+
+	// Fallback: check resolv.conf directly
+	output, err = runSSHCommandOutput(paths, user, ip, "cat", "/etc/resolv.conf")
+	if err == nil && strings.Contains(string(output), gateway) {
+		result.Passed = true
+		result.Details = "DNS=" + gateway + " (resolv.conf)"
+		return result
+	}
+
+	result.Passed = false
+	result.Details = "abox DNS config not found"
+	result.Hint = hintCheckCloudInit
 	return result
 }


### PR DESCRIPTION
- Add RPM packaging to goreleaser with correct zsh completion paths
- Remove hardcoded qemu emulator path, let libvirt auto-detect
- Detect QEMU disk groups dynamically (libvirt-qemu, qemu, kvm)
- Warn when firewalld is active (conflicts with iptables NAT rules)
- Support systemd-resolved, NetworkManager, and resolv.conf in doctor