### PR TITLE
chore: clean up lint warnings (goconst, modernize, nolintlint)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.12.1
 
   build:
     name: Build

--- a/internal/allowlist/loader.go
+++ b/internal/allowlist/loader.go
@@ -27,7 +27,7 @@ func OpenFileNoFollow(path string, flag int, perm os.FileMode) (*os.File, error)
 		}
 		return nil, err
 	}
-	return os.NewFile(uintptr(fd), path), nil //nolint:gosec // fd comes from unix.Open, safe conversion
+	return os.NewFile(uintptr(fd), path), nil
 }
 
 // Loader handles loading and watching the allowlist configuration file.

--- a/internal/boxfile/boxfile.go
+++ b/internal/boxfile/boxfile.go
@@ -63,11 +63,11 @@ func DefaultBoxfile() *Boxfile {
 		Version: CurrentBoxfileVersion,
 		CPUs:    2,
 		Memory:  4096,
-		Disk:    "20G",
-		Base:    "ubuntu-24.04",
+		Disk:    config.DefaultDisk,
+		Base:    config.DefaultBase,
 		User:    "ubuntu",
 		DNS: BoxfileDNS{
-			Upstream: "8.8.8.8:53",
+			Upstream: config.DefaultUpstream,
 		},
 		HTTP: BoxfileHTTP{
 			MITM: &mitmDefault,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,7 +64,7 @@ func AcquireLock() error {
 	}
 
 	// Acquire exclusive lock (blocks until available)
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil { //nolint:gosec // fd from os.File, safe conversion
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
 		f.Close()
 		return fmt.Errorf("failed to acquire lock: %w", err)
 	}
@@ -80,7 +80,7 @@ func ReleaseLock() error {
 	}
 
 	// Release the lock
-	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN); err != nil { //nolint:gosec // fd from os.File, safe conversion
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN); err != nil {
 		lockFile.Close()
 		lockFile = nil
 		return fmt.Errorf("failed to release lock: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,8 +21,21 @@ import (
 // This location is accessible by the libvirt-qemu user, unlike user home directories.
 const LibvirtImagesDir = "/var/lib/libvirt/images/abox"
 
-// defaultUser is the default SSH username for Ubuntu and unknown base images.
-const defaultUser = "ubuntu"
+// Default values for new instances.
+const (
+	DefaultBase     = "ubuntu-24.04"
+	DefaultDisk     = "20G"
+	DefaultUpstream = "8.8.8.8:53"
+)
+
+// SSH usernames for supported distros.
+const (
+	defaultUser   = "ubuntu" // also used for unknown base images
+	userAlmaLinux = "almalinux"
+	userRocky     = "cloud-user"
+	userCentOS    = "centos"
+	userDebian    = "debian"
+)
 
 // lockFile holds the file descriptor for the global lock.
 // Note: This global is safe because abox is a single-threaded CLI tool.
@@ -148,13 +161,13 @@ type Instance struct {
 func DefaultUserForBase(base string) string {
 	switch {
 	case strings.HasPrefix(base, "almalinux-"):
-		return "almalinux"
+		return userAlmaLinux
 	case strings.HasPrefix(base, "rocky-"):
-		return "cloud-user"
+		return userRocky
 	case strings.HasPrefix(base, "centos-"):
-		return "centos"
+		return userCentOS
 	case strings.HasPrefix(base, "debian-"):
-		return "debian"
+		return userDebian
 	default:
 		return defaultUser
 	}
@@ -220,14 +233,14 @@ func DefaultInstance(name string) *Instance {
 		Name:    name,
 		CPUs:    2,
 		Memory:  4096,
-		Base:    "ubuntu-24.04",
+		Base:    DefaultBase,
 		DNS: DNSConfig{
-			Upstream: "8.8.8.8:53",
+			Upstream: DefaultUpstream,
 		},
 		HTTP: HTTPConfig{
 			MITM: true, // Default to enabled for security
 		},
-		Disk: "20G",
+		Disk: DefaultDisk,
 	}
 }
 

--- a/internal/config/filesystem.go
+++ b/internal/config/filesystem.go
@@ -87,6 +87,9 @@ func SetFileSystem(f FileSystem) FileSystem {
 	return prev
 }
 
+// mockHomeDir is the default HomeDir used by MockFileSystem and tests.
+const mockHomeDir = "/home/testuser"
+
 // MockFileSystem is a FileSystem implementation for testing.
 type MockFileSystem struct {
 	Files      map[string][]byte        // path -> content
@@ -113,7 +116,7 @@ func NewMockFileSystem() *MockFileSystem {
 		Dirs:       make(map[string]bool),
 		DirEntries: make(map[string][]os.DirEntry),
 		EnvVars:    make(map[string]string),
-		HomeDir:    "/home/testuser",
+		HomeDir:    mockHomeDir,
 	}
 }
 

--- a/internal/filtercmd/command.go
+++ b/internal/filtercmd/command.go
@@ -9,6 +9,9 @@ import (
 	"github.com/sandialabs/abox/pkg/cmd/completion"
 )
 
+// logsCmdUse is the cobra Use string shared by all filter logs subcommands.
+const logsCmdUse = "logs <instance>"
+
 // LogsConfig holds configuration for creating a logs command.
 type LogsConfig struct {
 	// Use is the command use string (e.g., "logs <instance>")
@@ -59,7 +62,7 @@ func NewLogsCommand(w io.Writer, cfg LogsConfig) *cobra.Command {
 // NewDNSLogsCommand creates the standard DNS logs command.
 func NewDNSLogsCommand(w io.Writer) *cobra.Command {
 	return NewLogsCommand(w, LogsConfig{
-		Use:   "logs <instance>",
+		Use:   logsCmdUse,
 		Short: "View DNS filter logs",
 		Long: `View the DNS filter logs for an instance.
 
@@ -87,7 +90,7 @@ Use --jq to filter JSON traffic logs with a jq expression.`,
 // NewHTTPLogsCommand creates the standard HTTP logs command.
 func NewHTTPLogsCommand(w io.Writer) *cobra.Command {
 	return NewLogsCommand(w, LogsConfig{
-		Use:   "logs <instance>",
+		Use:   logsCmdUse,
 		Short: "View HTTP filter logs",
 		Long: `View the HTTP filter logs for an instance.
 
@@ -112,7 +115,7 @@ Use --jq to filter JSON traffic logs with a jq expression.`,
 // NewMonitorLogsCommand creates the standard monitor logs command.
 func NewMonitorLogsCommand(w io.Writer) *cobra.Command {
 	return NewLogsCommand(w, LogsConfig{
-		Use:   "logs <instance>",
+		Use:   logsCmdUse,
 		Short: "View monitor logs",
 		Long: `View Tetragon monitoring events from the VM.
 

--- a/internal/images/almalinux.go
+++ b/internal/images/almalinux.go
@@ -28,7 +28,7 @@ func NewAlmaLinuxProvider() *AlmaLinuxProvider {
 
 // Name returns the provider name.
 func (p *AlmaLinuxProvider) Name() string {
-	return "almalinux"
+	return providerAlmaLinux
 }
 
 // almalinuxRelease holds release info for AlmaLinux.
@@ -105,7 +105,7 @@ func (p *AlmaLinuxProvider) fetchImageInfo(ctx context.Context, rel almalinuxRel
 		URL:         imageURL,
 		Hash:        hash,
 		HashAlgo:    "sha256",
-		Provider:    "almalinux",
+		Provider:    providerAlmaLinux,
 	}, nil
 }
 

--- a/internal/images/debian.go
+++ b/internal/images/debian.go
@@ -29,7 +29,7 @@ func NewDebianProvider() *DebianProvider {
 
 // Name returns the provider name.
 func (p *DebianProvider) Name() string {
-	return "debian"
+	return providerDebian
 }
 
 // debianRelease holds parsed release info from debian.csv.
@@ -263,7 +263,7 @@ func (p *DebianProvider) fetchImageInfo(ctx context.Context, rel debianRelease) 
 		URL:         imageURL,
 		Hash:        hash,
 		HashAlgo:    "sha512",
-		Provider:    "debian",
+		Provider:    providerDebian,
 	}, nil
 }
 

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -193,16 +193,27 @@ func GroupByProvider(images []ImageInfo) map[string][]ImageInfo {
 	return groups
 }
 
+// Provider identifiers used in ImageInfo.Provider, image catalog keys, and CLI selection.
+// Values are part of the user-facing API and must not change.
+const (
+	providerAlmaLinux = "almalinux"
+	providerDebian    = "debian"
+	providerUbuntu    = "ubuntu"
+)
+
+// archAMD64 is the architecture identifier used by upstream image catalogs.
+const archAMD64 = "amd64"
+
 // ProviderOrder returns the canonical display order for providers.
 func ProviderOrder() []string {
-	return []string{"almalinux", "debian", "ubuntu"}
+	return []string{providerAlmaLinux, providerDebian, providerUbuntu}
 }
 
 // providerDisplayNames maps provider identifiers to their proper display names.
 var providerDisplayNames = map[string]string{
-	"almalinux": "AlmaLinux",
-	"debian":    "Debian",
-	"ubuntu":    "Ubuntu",
+	providerAlmaLinux: "AlmaLinux",
+	providerDebian:    "Debian",
+	providerUbuntu:    "Ubuntu",
 }
 
 // ProviderDisplayName returns the display name for a provider.

--- a/internal/images/lock.go
+++ b/internal/images/lock.go
@@ -16,7 +16,7 @@ type lockCloser struct {
 
 func (l *lockCloser) Close() error {
 	defer l.f.Close()
-	return syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN) //nolint:gosec // fd from os.File, safe conversion
+	return syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
 }
 
 // LockBaseImage acquires a flock on a base image file.
@@ -28,7 +28,7 @@ func LockBaseImage(path string, lockType int) (io.Closer, error) {
 		return nil, fmt.Errorf("failed to open base image for locking: %w", err)
 	}
 
-	if err := syscall.Flock(int(f.Fd()), lockType); err != nil { //nolint:gosec // fd from os.File, safe conversion
+	if err := syscall.Flock(int(f.Fd()), lockType); err != nil {
 		f.Close()
 		return nil, fmt.Errorf("failed to acquire lock on base image: %w", err)
 	}

--- a/internal/images/ubuntu.go
+++ b/internal/images/ubuntu.go
@@ -27,7 +27,7 @@ func NewUbuntuProvider() *UbuntuProvider {
 
 // Name returns the provider name.
 func (p *UbuntuProvider) Name() string {
-	return "ubuntu"
+	return providerUbuntu
 }
 
 // minUbuntuVersion is the minimum Ubuntu LTS version to offer.
@@ -87,7 +87,7 @@ func parseCatalog(catalog *ubuntuCatalog) ([]ImageInfo, error) {
 	var images []ImageInfo
 
 	for _, product := range catalog.Products {
-		if product.Arch != "amd64" {
+		if product.Arch != archAMD64 {
 			continue
 		}
 		if !product.Supported {
@@ -124,7 +124,7 @@ func parseCatalog(catalog *ubuntuCatalog) ([]ImageInfo, error) {
 			URL:         "https://cloud-images.ubuntu.com/" + disk.Path,
 			Hash:        disk.SHA256,
 			HashAlgo:    "sha256",
-			Provider:    "ubuntu",
+			Provider:    providerUbuntu,
 		})
 	}
 

--- a/internal/libvirt/libvirt.go
+++ b/internal/libvirt/libvirt.go
@@ -465,20 +465,26 @@ func DomainExists(name string) bool {
 	return virshOutputContainsLine(name, "list", "--all", "--name")
 }
 
+// virsh domstate output values.
+const (
+	domStateRunning = "running"
+	domStateUnknown = "unknown"
+)
+
 // DomainIsRunning checks if a domain is running.
 func DomainIsRunning(name string) bool {
 	output, err := virsh("domstate", name)
 	if err != nil {
 		return false
 	}
-	return strings.TrimSpace(output) == "running"
+	return strings.TrimSpace(output) == domStateRunning
 }
 
 // DomainState returns the state of a domain.
 func DomainState(name string) string {
 	output, err := virsh("domstate", name)
 	if err != nil {
-		return "unknown"
+		return domStateUnknown
 	}
 	return strings.TrimSpace(output)
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -156,20 +156,25 @@ func CloseLogFile() {
 	}
 }
 
-const levelInfo = "info"
+const (
+	levelDebug = "debug"
+	levelInfo  = "info"
+	levelWarn  = "warn"
+	levelError = "error"
+)
 
 // ParseLevel parses a log level string and returns the corresponding slog.Level.
 // Valid values are "debug", "info", "warn"/"warning", and "error".
 // Returns slog.LevelInfo for empty or invalid values.
 func ParseLevel(s string) slog.Level {
 	switch strings.ToLower(s) {
-	case "debug":
+	case levelDebug:
 		return slog.LevelDebug
 	case levelInfo, "":
 		return slog.LevelInfo
-	case "warn", "warning":
+	case levelWarn, "warning":
 		return slog.LevelWarn
-	case "error":
+	case levelError:
 		return slog.LevelError
 	default:
 		return slog.LevelInfo
@@ -190,20 +195,20 @@ func GetLevel() slog.Level {
 func LevelString(level slog.Level) string {
 	switch level {
 	case slog.LevelDebug:
-		return "debug"
+		return levelDebug
 	case slog.LevelInfo:
 		return levelInfo
 	case slog.LevelWarn:
-		return "warn"
+		return levelWarn
 	case slog.LevelError:
-		return "error"
+		return levelError
 	default:
 		return levelInfo
 	}
 }
 
 // ValidLevels are the accepted log level values.
-var ValidLevels = []string{"debug", "info", "warn", "error"}
+var ValidLevels = []string{levelDebug, levelInfo, levelWarn, levelError}
 
 // IsValidLevel returns true if the given level string is a valid log level.
 func IsValidLevel(level string) bool {

--- a/internal/privilege/helper.go
+++ b/internal/privilege/helper.go
@@ -537,7 +537,7 @@ func openNoFollow(path string) (*os.File, error) {
 		}
 		return nil, err
 	}
-	return os.NewFile(uintptr(fd), path), nil //nolint:gosec // fd comes from unix.Open, safe conversion
+	return os.NewFile(uintptr(fd), path), nil
 }
 
 // resolvePathNoFollow opens a file with O_NOFOLLOW and returns its real path.

--- a/internal/privilege/helper.go
+++ b/internal/privilege/helper.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -840,8 +841,7 @@ func (s *PrivilegeServer) flushNATRules(bridge string) {
 		}
 	}
 
-	for i := len(rulesToDelete) - 1; i >= 0; i-- {
-		rule := rulesToDelete[i]
+	for _, rule := range slices.Backward(rulesToDelete) {
 		rule = strings.TrimPrefix(rule, "-A ")
 		args := []string{"-w", "-t", "nat", "-D"}
 		// strings.Fields safely splits on whitespace; iptables -S output contains
@@ -882,8 +882,7 @@ func (s *PrivilegeServer) flushInputRules(bridge string) {
 		}
 	}
 
-	for i := len(rulesToDelete) - 1; i >= 0; i-- {
-		rule := rulesToDelete[i]
+	for _, rule := range slices.Backward(rulesToDelete) {
 		rule = strings.TrimPrefix(rule, "-A ")
 		args := []string{"-w", "-D"}
 		args = append(args, strings.Fields(rule)...)

--- a/internal/privilege/helper.go
+++ b/internal/privilege/helper.go
@@ -27,6 +27,15 @@ import (
 	"github.com/sandialabs/abox/internal/rpc"
 )
 
+// pingResponse is the body of the Ping RPC response.
+const pingResponse = "pong"
+
+// Supported iptables protocols for DNS/HTTP redirect rules.
+const (
+	protoTCP = "tcp"
+	protoUDP = "udp"
+)
+
 // resolvedCommands holds absolute paths for external commands.
 // These are resolved once at startup and cached for the process lifetime.
 var resolvedCommands struct {
@@ -269,7 +278,7 @@ func auditInterceptor() grpc.UnaryServerInterceptor {
 
 // Ping handles the ping operation (health check).
 func (s *PrivilegeServer) Ping(ctx context.Context, req *rpc.Empty) (*rpc.StringMsg, error) {
-	return &rpc.StringMsg{Message: "pong"}, nil
+	return &rpc.StringMsg{Message: pingResponse}, nil
 }
 
 // shutdownState holds the gRPC server for coordinated shutdown.
@@ -670,7 +679,7 @@ func validateIptablesReq(req *rpc.IptablesReq) (string, error) {
 	if err := ValidateBridgeName(req.Bridge); err != nil {
 		return "", err
 	}
-	if req.Protocol != "udp" && req.Protocol != "tcp" {
+	if req.Protocol != protoUDP && req.Protocol != protoTCP {
 		return "", fmt.Errorf("protocol must be 'udp' or 'tcp', got: %s", req.Protocol)
 	}
 	port := int(req.DnsPort)

--- a/internal/privilege/validation.go
+++ b/internal/privilege/validation.go
@@ -9,9 +9,14 @@ import (
 	"strings"
 )
 
+// libvirtImagesDir is the privileged-helper-managed disk image storage root.
+// Mirrors config.LibvirtImagesDir; kept local to avoid importing config from
+// the privilege helper, which must be a leaf package for the setuid binary.
+const libvirtImagesDir = "/var/lib/libvirt/images/abox"
+
 // Allowed base paths for privileged operations.
 var allowedPaths = []string{
-	"/var/lib/libvirt/images/abox",
+	libvirtImagesDir,
 }
 
 // safePathChars matches strings containing ONLY safe path characters.

--- a/internal/rpc/peercred.go
+++ b/internal/rpc/peercred.go
@@ -23,7 +23,7 @@ func GetPeerCredentials(conn net.Conn) (pid int, uid int, err error) {
 	var cred *unix.Ucred
 	var credErr error
 	err = rawConn.Control(func(fd uintptr) {
-		cred, credErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED) //nolint:gosec // fd from rawConn, safe conversion
+		cred, credErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
 	})
 	if err != nil {
 		return 0, 0, err

--- a/internal/sshutil/sshutil.go
+++ b/internal/sshutil/sshutil.go
@@ -21,13 +21,20 @@ import (
 // This protects against MITM attacks after first connection while allowing
 // ephemeral VMs to work smoothly. If a host key changes unexpectedly, SSH
 // will refuse to connect, alerting to a potential attack.
+// SSH options shared by all abox SSH/SCP invocations.
+const (
+	sshOptStrictHostKey = "StrictHostKeyChecking=accept-new"
+	sshOptControlPath   = "ControlPath=none"
+	sshOptLogLevel      = "LogLevel=ERROR"
+)
+
 func CommonOptions(paths *config.Paths) []string {
 	return []string{
 		"-i", paths.SSHKey,
-		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", sshOptStrictHostKey,
 		"-o", "UserKnownHostsFile=" + paths.KnownHosts,
-		"-o", "ControlPath=none",
-		"-o", "LogLevel=ERROR",
+		"-o", sshOptControlPath,
+		"-o", sshOptLogLevel,
 	}
 }
 

--- a/internal/tetragon/policy/policy.go
+++ b/internal/tetragon/policy/policy.go
@@ -81,6 +81,36 @@ const (
 	EventTypeSecurity EventType = "security"
 )
 
+// Kernel hook (kprobe) names. These flow into Tetragon JSON events and are
+// parsed verbatim by callers; values must remain byte-for-byte identical.
+const (
+	kpSecurityFileOpen      = "security_file_open"
+	kpVfsUnlink             = "vfs_unlink"
+	kpVfsRename             = "vfs_rename"
+	kpSecuritySocketConnect = "security_socket_connect"
+	kpInetCskListenStart    = "inet_csk_listen_start"
+	kpSecurityBPRMCheck     = "security_bprm_check"
+	kpCommitCreds           = "commit_creds"
+	kpDoInitModule          = "do_init_module"
+	kpSysSetuid             = "sys_setuid"
+	kpSysPtrace             = "sys_ptrace"
+	kpPathMount             = "path_mount"
+	kpTCPClose              = "tcp_close"
+)
+
+// Kprobe spec literals (Tetragon CRD field values).
+const (
+	actionPost        = "Post"
+	operatorNotPrefix = "NotPrefix"
+	argTypeString     = "string"
+)
+
+// TracingPolicy CRD constants. External API contract — values must not change.
+const (
+	tracingPolicyAPIVersion = "cilium.io/v1alpha1"
+	tracingPolicyKind       = "TracingPolicy"
+)
+
 // CuratedKprobe holds a kprobe definition along with its event parser metadata.
 type CuratedKprobe struct {
 	Spec      KprobeSpec
@@ -90,64 +120,64 @@ type CuratedKprobe struct {
 
 // defaultOrder defines the canonical ordering of default kprobes.
 var defaultOrder = []string{
-	"security_file_open",
-	"vfs_unlink",
-	"vfs_rename",
-	"security_socket_connect",
-	"inet_csk_listen_start",
+	kpSecurityFileOpen,
+	kpVfsUnlink,
+	kpVfsRename,
+	kpSecuritySocketConnect,
+	kpInetCskListenStart,
 }
 
 // Registry maps kernel function names to their curated kprobe definitions.
 var Registry = map[string]CuratedKprobe{
-	"security_file_open": {
+	kpSecurityFileOpen: {
 		Spec: KprobeSpec{
-			Call: "security_file_open",
-			Args: []KprobeArg{{Index: 0, Type: "file"}},
+			Call: kpSecurityFileOpen,
+			Args: []KprobeArg{{Index: 0, Type: string(EventTypeFile)}},
 			Selectors: []SelectorSpec{{
 				MatchArgs: []MatchArgSpec{{
 					Index:    0,
-					Operator: "NotPrefix",
+					Operator: operatorNotPrefix,
 					Values:   []string{"/dev/vport", "/var/log/tetragon/", "/proc/", "/sys/"},
 				}},
-				MatchActions: []MatchActionSpec{{Action: "Post"}},
+				MatchActions: []MatchActionSpec{{Action: actionPost}},
 			}},
 		},
 		EventType: EventTypeFile,
 		Op:        "open",
 	},
-	"vfs_unlink": {
+	kpVfsUnlink: {
 		Spec: KprobeSpec{
-			Call: "vfs_unlink",
-			Args: []KprobeArg{{Index: 2, Type: "file"}},
+			Call: kpVfsUnlink,
+			Args: []KprobeArg{{Index: 2, Type: string(EventTypeFile)}},
 			Selectors: []SelectorSpec{{
 				MatchArgs: []MatchArgSpec{{
 					Index:    2,
-					Operator: "NotPrefix",
+					Operator: operatorNotPrefix,
 					Values:   []string{"/proc/", "/sys/"},
 				}},
-				MatchActions: []MatchActionSpec{{Action: "Post"}},
+				MatchActions: []MatchActionSpec{{Action: actionPost}},
 			}},
 		},
 		EventType: EventTypeFile,
 		Op:        "delete",
 	},
-	"vfs_rename": {
+	kpVfsRename: {
 		Spec: KprobeSpec{
-			Call: "vfs_rename",
+			Call: kpVfsRename,
 			Args: []KprobeArg{
-				{Index: 1, Type: "file"},
-				{Index: 3, Type: "file"},
+				{Index: 1, Type: string(EventTypeFile)},
+				{Index: 3, Type: string(EventTypeFile)},
 			},
 			Selectors: []SelectorSpec{{
-				MatchActions: []MatchActionSpec{{Action: "Post"}},
+				MatchActions: []MatchActionSpec{{Action: actionPost}},
 			}},
 		},
 		EventType: EventTypeFile,
 		Op:        "rename",
 	},
-	"security_socket_connect": {
+	kpSecuritySocketConnect: {
 		Spec: KprobeSpec{
-			Call: "security_socket_connect",
+			Call: kpSecuritySocketConnect,
 			Args: []KprobeArg{{Index: 1, Type: "sockaddr"}},
 			Selectors: []SelectorSpec{{
 				MatchArgs: []MatchArgSpec{{
@@ -155,18 +185,18 @@ var Registry = map[string]CuratedKprobe{
 					Operator: "Family",
 					Values:   []string{"AF_INET", "AF_INET6"},
 				}},
-				MatchActions: []MatchActionSpec{{Action: "Post"}},
+				MatchActions: []MatchActionSpec{{Action: actionPost}},
 			}},
 		},
 		EventType: EventTypeNetwork,
 		Op:        "connect",
 	},
-	"inet_csk_listen_start": {
+	kpInetCskListenStart: {
 		Spec: KprobeSpec{
-			Call: "inet_csk_listen_start",
+			Call: kpInetCskListenStart,
 			Args: []KprobeArg{{Index: 0, Type: "sock"}},
 			Selectors: []SelectorSpec{{
-				MatchActions: []MatchActionSpec{{Action: "Post"}},
+				MatchActions: []MatchActionSpec{{Action: actionPost}},
 			}},
 		},
 		EventType: EventTypeNetwork,
@@ -175,42 +205,42 @@ var Registry = map[string]CuratedKprobe{
 
 	// --- Security monitoring (opt-in) ---
 
-	"security_bprm_check": {
+	kpSecurityBPRMCheck: {
 		Spec: KprobeSpec{
-			Call: "security_bprm_check",
+			Call: kpSecurityBPRMCheck,
 			Args: []KprobeArg{{Index: 0, Type: "linux_binprm"}},
 			Selectors: []SelectorSpec{{
-				MatchActions: []MatchActionSpec{{Action: "Post"}},
+				MatchActions: []MatchActionSpec{{Action: actionPost}},
 			}},
 		},
 		EventType: EventTypeSecurity,
 		Op:        "exec_check",
 	},
-	"commit_creds": {
+	kpCommitCreds: {
 		Spec: KprobeSpec{
-			Call: "commit_creds",
+			Call: kpCommitCreds,
 			Args: []KprobeArg{{Index: 0, Type: "cred"}},
 			Selectors: []SelectorSpec{{
-				MatchActions: []MatchActionSpec{{Action: "Post"}},
+				MatchActions: []MatchActionSpec{{Action: actionPost}},
 			}},
 		},
 		EventType: EventTypeSecurity,
 		Op:        "cred_change",
 	},
-	"do_init_module": {
+	kpDoInitModule: {
 		Spec: KprobeSpec{
-			Call: "do_init_module",
+			Call: kpDoInitModule,
 			Args: []KprobeArg{{Index: 0, Type: "module"}},
 			Selectors: []SelectorSpec{{
-				MatchActions: []MatchActionSpec{{Action: "Post"}},
+				MatchActions: []MatchActionSpec{{Action: actionPost}},
 			}},
 		},
 		EventType: EventTypeSecurity,
 		Op:        "module_load",
 	},
-	"sys_setuid": {
+	kpSysSetuid: {
 		Spec: KprobeSpec{
-			Call:    "sys_setuid",
+			Call:    kpSysSetuid,
 			Syscall: true,
 			Args:    []KprobeArg{{Index: 0, Type: "int"}},
 			Selectors: []SelectorSpec{{
@@ -219,7 +249,7 @@ var Registry = map[string]CuratedKprobe{
 					Operator: "Equal",
 					Values:   []string{"0"},
 				}},
-				MatchActions: []MatchActionSpec{{Action: "Post"}},
+				MatchActions: []MatchActionSpec{{Action: actionPost}},
 			}},
 		},
 		EventType: EventTypeSecurity,
@@ -228,28 +258,28 @@ var Registry = map[string]CuratedKprobe{
 
 	// --- Behavioral monitoring (opt-in) ---
 
-	"sys_ptrace": {
+	kpSysPtrace: {
 		Spec: KprobeSpec{
-			Call:    "sys_ptrace",
+			Call:    kpSysPtrace,
 			Syscall: true,
 			Args:    []KprobeArg{{Index: 0, Type: "int"}},
 			Selectors: []SelectorSpec{{
-				MatchActions: []MatchActionSpec{{Action: "Post"}},
+				MatchActions: []MatchActionSpec{{Action: actionPost}},
 			}},
 		},
 		EventType: EventTypeSecurity,
 		Op:        "ptrace",
 	},
-	"path_mount": {
+	kpPathMount: {
 		Spec: KprobeSpec{
-			Call: "path_mount",
+			Call: kpPathMount,
 			Args: []KprobeArg{
-				{Index: 0, Type: "string"},
+				{Index: 0, Type: argTypeString},
 				{Index: 1, Type: "path"},
-				{Index: 2, Type: "string"},
+				{Index: 2, Type: argTypeString},
 			},
 			Selectors: []SelectorSpec{{
-				MatchActions: []MatchActionSpec{{Action: "Post"}},
+				MatchActions: []MatchActionSpec{{Action: actionPost}},
 			}},
 		},
 		EventType: EventTypeSecurity,
@@ -258,12 +288,12 @@ var Registry = map[string]CuratedKprobe{
 
 	// --- Additional network (opt-in) ---
 
-	"tcp_close": {
+	kpTCPClose: {
 		Spec: KprobeSpec{
-			Call: "tcp_close",
+			Call: kpTCPClose,
 			Args: []KprobeArg{{Index: 0, Type: "sock"}},
 			Selectors: []SelectorSpec{{
-				MatchActions: []MatchActionSpec{{Action: "Post"}},
+				MatchActions: []MatchActionSpec{{Action: actionPost}},
 			}},
 		},
 		EventType: EventTypeNetwork,
@@ -317,8 +347,8 @@ func RenderPolicy(names []string) ([]byte, error) {
 	}
 
 	policy := TracingPolicy{
-		APIVersion: "cilium.io/v1alpha1",
-		Kind:       "TracingPolicy",
+		APIVersion: tracingPolicyAPIVersion,
+		Kind:       tracingPolicyKind,
 		Metadata:   TracingPolicyMeta{Name: "abox-monitor"},
 		Spec:       TracingPolicySpec{Kprobes: specs},
 	}
@@ -349,8 +379,8 @@ func RenderPerKrobePolicies(names []string) (map[string][]byte, error) {
 		spec.Ignore = &KprobeIgnore{CallNotFound: true}
 
 		p := TracingPolicy{
-			APIVersion: "cilium.io/v1alpha1",
-			Kind:       "TracingPolicy",
+			APIVersion: tracingPolicyAPIVersion,
+			Kind:       tracingPolicyKind,
 			Metadata:   TracingPolicyMeta{Name: "abox-" + strings.ReplaceAll(name, "_", "-")},
 			Spec:       TracingPolicySpec{Kprobes: []KprobeSpec{spec}},
 		}

--- a/internal/tetragon/tetragon.go
+++ b/internal/tetragon/tetragon.go
@@ -16,6 +16,9 @@ import (
 	"time"
 )
 
+// hashAlgoSHA256 identifies the SHA-256 hash algorithm in ReleaseInfo.HashAlgo.
+const hashAlgoSHA256 = "sha256"
+
 // ReleaseInfo contains metadata for a downloadable Tetragon release.
 type ReleaseInfo struct {
 	Version  string `json:"version"`   // e.g., "v1.6.0"
@@ -251,7 +254,7 @@ func parseRelease(ctx context.Context, release *githubRelease) (*ReleaseInfo, er
 		Version:  version,
 		URL:      tarballURL,
 		Hash:     hash,
-		HashAlgo: "sha256",
+		HashAlgo: hashAlgoSHA256,
 	}, nil
 }
 

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -317,13 +317,25 @@ func NormalizeUpstreamDNS(upstream string) (string, error) {
 	return net.JoinHostPort(host, port), nil
 }
 
+// Log level and format identifiers. Mirrored in internal/logging; kept local
+// here to avoid an import cycle.
+const (
+	logLevelDebug   = "debug"
+	logLevelInfo    = "info"
+	logLevelWarn    = "warn"
+	logLevelWarning = "warning"
+	logLevelError   = "error"
+	logFormatText   = "text"
+	logFormatJSON   = "json"
+)
+
 // validLogLevels contains the set of valid log level values.
 var validLogLevels = map[string]bool{
-	"debug":   true,
-	"info":    true,
-	"warn":    true,
-	"warning": true,
-	"error":   true,
+	logLevelDebug:   true,
+	logLevelInfo:    true,
+	logLevelWarn:    true,
+	logLevelWarning: true,
+	logLevelError:   true,
 }
 
 // ValidateLogLevel validates a log level string.
@@ -342,8 +354,8 @@ func ValidateLogLevel(level string) error {
 
 // validLogFormats contains the set of valid log format values.
 var validLogFormats = map[string]bool{
-	"text": true,
-	"json": true,
+	logFormatText: true,
+	logFormatJSON: true,
 }
 
 // ValidateLogFormat validates a log format string.

--- a/pkg/cmd/checkdeps/checkdeps.go
+++ b/pkg/cmd/checkdeps/checkdeps.go
@@ -205,13 +205,14 @@ func checkExecutable(name string) error {
 }
 
 func installHint(name string) string {
+	const hintOpenSSHClient = "install openssh-client"
 	hints := map[string]string{
 		"virsh":       "install libvirt-clients (Debian/Ubuntu) or libvirt (Fedora/Arch)",
 		"qemu-img":    "install qemu-utils (Debian/Ubuntu) or qemu-img (Fedora/Arch)",
-		"ssh":         "install openssh-client",
-		"scp":         "install openssh-client",
+		"ssh":         hintOpenSSHClient,
+		"scp":         hintOpenSSHClient,
 		"sshfs":       "install sshfs",
-		"ssh-keygen":  "install openssh-client",
+		"ssh-keygen":  hintOpenSSHClient,
 		"genisoimage": "install genisoimage (Debian/Ubuntu) or cdrkit (Fedora/Arch)",
 		"xorriso":     "install xorriso",
 		"pkexec":      "install polkit (usually pre-installed)",

--- a/pkg/cmd/doctor/checks.go
+++ b/pkg/cmd/doctor/checks.go
@@ -163,24 +163,44 @@ const (
 	CheckHTTPUpstream CheckID = "httpupstream"
 )
 
+// User-visible check names. These appear in CLI output and TUI.
+const (
+	CheckNameConfig       = "Instance configuration valid"
+	CheckNameVMRunning    = "VM running"
+	CheckNameBridge       = "Network bridge active"
+	CheckNameVMIP         = "VM IP address"
+	CheckNameHostDisk     = "Host disk space"
+	CheckNameDNSFilter    = "DNS filter running"
+	CheckNameHTTPFilter   = "HTTP filter running"
+	CheckNameDNSUpstream  = "DNS upstream reachable"
+	CheckNameSSH          = "SSH connection"
+	CheckNameGateway      = "Gateway reachable"
+	CheckNameDNSResolve   = "DNS resolution working"
+	CheckNameHTTPProxy    = "HTTP proxy reachable"
+	CheckNameGuestDisk    = "Guest disk space"
+	CheckNameProxyEnv     = "Proxy environment variables"
+	CheckNameDNSConfig    = "DNS configuration"
+	CheckNameHTTPUpstream = "HTTP upstream reachable"
+)
+
 // checkNameToID maps result names to check IDs.
 var checkNameToID = map[string]CheckID{
-	"Instance configuration valid": CheckConfig,
-	"VM running":                   CheckVM,
-	"Network bridge active":        CheckBridge,
-	"VM IP address":                CheckVMIP,
-	"Host disk space":              CheckHostDisk,
-	"DNS filter running":           CheckDNSFilter,
-	"HTTP filter running":          CheckHTTPFilter,
-	"DNS upstream reachable":       CheckDNSUpstream,
-	"SSH connection":               CheckSSH,
-	"Gateway reachable":            CheckGateway,
-	"DNS resolution working":       CheckDNSResolve,
-	"HTTP proxy reachable":         CheckHTTPProxy,
-	"Guest disk space":             CheckGuestDisk,
-	"Proxy environment variables":  CheckProxyEnv,
-	"DNS configuration":            CheckDNSConfig,
-	"HTTP upstream reachable":      CheckHTTPUpstream,
+	CheckNameConfig:       CheckConfig,
+	CheckNameVMRunning:    CheckVM,
+	CheckNameBridge:       CheckBridge,
+	CheckNameVMIP:         CheckVMIP,
+	CheckNameHostDisk:     CheckHostDisk,
+	CheckNameDNSFilter:    CheckDNSFilter,
+	CheckNameHTTPFilter:   CheckHTTPFilter,
+	CheckNameDNSUpstream:  CheckDNSUpstream,
+	CheckNameSSH:          CheckSSH,
+	CheckNameGateway:      CheckGateway,
+	CheckNameDNSResolve:   CheckDNSResolve,
+	CheckNameHTTPProxy:    CheckHTTPProxy,
+	CheckNameGuestDisk:    CheckGuestDisk,
+	CheckNameProxyEnv:     CheckProxyEnv,
+	CheckNameDNSConfig:    CheckDNSConfig,
+	CheckNameHTTPUpstream: CheckHTTPUpstream,
 }
 
 // CheckIDFromName returns the CheckID for a given check result name.

--- a/pkg/cmd/doctor/doctor.go
+++ b/pkg/cmd/doctor/doctor.go
@@ -152,7 +152,7 @@ func runDoctor(w io.Writer, name string) error {
 	fmt.Fprintln(w, "\n[VM Connectivity]")
 
 	// Check 7: SSH connection
-	result = CheckResult{Name: "SSH connection"}
+	result = CheckResult{Name: CheckNameSSH}
 	if vmRunning && vmIP != "" {
 		if testSSH(paths, inst.GetUser(), vmIP) {
 			result.Passed = true
@@ -192,7 +192,7 @@ func runHostChecks(w io.Writer, name string) (results []CheckResult, inst *confi
 	// Check 1: Instance configuration
 	var err error
 	inst, paths, err = instance.LoadRequired(name)
-	result := CheckResult{Name: "Instance configuration valid", Passed: err == nil}
+	result := CheckResult{Name: CheckNameConfig, Passed: err == nil}
 	if err != nil {
 		result.Details = err.Error()
 		result.Hint = "Check that the instance exists with 'abox list'"
@@ -219,7 +219,7 @@ func runHostChecks(w io.Writer, name string) (results []CheckResult, inst *confi
 	// Check 2: VM running
 	state := be.VM().State(name)
 	result = CheckResult{
-		Name:    "VM running",
+		Name:    CheckNameVMRunning,
 		Passed:  state == backend.VMStateRunning,
 		Details: fmt.Sprintf("state: %s", state),
 	}
@@ -233,7 +233,7 @@ func runHostChecks(w io.Writer, name string) (results []CheckResult, inst *confi
 
 	// Check 3: Network bridge active
 	networkActive := be.Network().IsActive(inst.Bridge)
-	result = CheckResult{Name: "Network bridge active", Passed: networkActive}
+	result = CheckResult{Name: CheckNameBridge, Passed: networkActive}
 	if networkActive {
 		result.Details = inst.Bridge
 	} else {
@@ -244,7 +244,7 @@ func runHostChecks(w io.Writer, name string) (results []CheckResult, inst *confi
 	results = append(results, result)
 
 	// Check 4: VM IP address
-	result = CheckResult{Name: "VM IP address"}
+	result = CheckResult{Name: CheckNameVMIP}
 	if !vmRunning {
 		result.Skipped = true
 	} else {
@@ -272,7 +272,7 @@ func runInVMChecks(w io.Writer, paths *config.Paths, inst *config.Instance, vmIP
 	var results []CheckResult
 
 	// Gateway ping
-	result := CheckResult{Name: "Gateway reachable"}
+	result := CheckResult{Name: CheckNameGateway}
 	switch {
 	case !sshWorks:
 		result.Skipped = true
@@ -301,11 +301,11 @@ func runInVMChecks(w io.Writer, paths *config.Paths, inst *config.Instance, vmIP
 		name string
 		fn   func() CheckResult
 	}{
-		{"Guest disk space", func() CheckResult { return checkGuestDiskSpace(paths, inst.GetUser(), vmIP) }},
-		{"Proxy environment variables", func() CheckResult {
+		{CheckNameGuestDisk, func() CheckResult { return checkGuestDiskSpace(paths, inst.GetUser(), vmIP) }},
+		{CheckNameProxyEnv, func() CheckResult {
 			return checkProxyEnvVars(paths, inst.GetUser(), vmIP, inst.Gateway, inst.HTTP.Port)
 		}},
-		{"DNS configuration", func() CheckResult { return checkDNSConfig(paths, inst.GetUser(), vmIP, inst.Gateway) }},
+		{CheckNameDNSConfig, func() CheckResult { return checkDNSConfig(paths, inst.GetUser(), vmIP, inst.Gateway) }},
 	} {
 		result = CheckResult{Name: check.name}
 		if sshWorks {
@@ -321,7 +321,7 @@ func runInVMChecks(w io.Writer, paths *config.Paths, inst *config.Instance, vmIP
 }
 
 func checkInVMDNS(paths *config.Paths, inst *config.Instance, vmIP string, sshWorks bool, dnsResult CheckResult) CheckResult {
-	result := CheckResult{Name: "DNS resolution working"}
+	result := CheckResult{Name: CheckNameDNSResolve}
 	if !sshWorks || !dnsResult.Passed {
 		result.Skipped = true
 		return result
@@ -340,7 +340,7 @@ func checkInVMDNS(paths *config.Paths, inst *config.Instance, vmIP string, sshWo
 }
 
 func checkInVMHTTP(paths *config.Paths, inst *config.Instance, vmIP string, sshWorks bool, httpResult CheckResult) CheckResult {
-	result := CheckResult{Name: "HTTP proxy reachable"}
+	result := CheckResult{Name: CheckNameHTTPProxy}
 	if !sshWorks || !httpResult.Passed {
 		result.Skipped = true
 		return result
@@ -467,7 +467,7 @@ func testHTTPProxy(paths *config.Paths, user, ip, gateway string, httpPort int) 
 
 // checkHostDiskSpace checks if there's enough disk space in the abox data directory.
 func checkHostDiskSpace(paths *config.Paths) CheckResult {
-	result := CheckResult{Name: "Host disk space"}
+	result := CheckResult{Name: CheckNameHostDisk}
 
 	// Check the instances directory which is under ~/.local/share/abox/
 	dataDir := paths.Instances
@@ -495,7 +495,7 @@ func checkHostDiskSpace(paths *config.Paths) CheckResult {
 
 // checkGuestDiskSpace checks if the guest has sufficient disk space.
 func checkGuestDiskSpace(paths *config.Paths, user, ip string) CheckResult {
-	result := CheckResult{Name: "Guest disk space"}
+	result := CheckResult{Name: CheckNameGuestDisk}
 
 	output, err := runSSHCommandOutput(paths, user, ip, "df", "-h", "/")
 	if err != nil {
@@ -541,7 +541,7 @@ func checkGuestDiskSpace(paths *config.Paths, user, ip string) CheckResult {
 
 // checkDNSUpstream tests if the upstream DNS server is reachable from the host.
 func checkDNSUpstream(inst *config.Instance) CheckResult {
-	result := CheckResult{Name: "DNS upstream reachable"}
+	result := CheckResult{Name: CheckNameDNSUpstream}
 
 	upstream := inst.DNS.Upstream
 	if upstream == "" {
@@ -572,7 +572,7 @@ func checkDNSUpstream(inst *config.Instance) CheckResult {
 
 // checkHTTPUpstream tests if the host can reach external HTTPS endpoints.
 func checkHTTPUpstream() CheckResult {
-	result := CheckResult{Name: "HTTP upstream reachable"}
+	result := CheckResult{Name: CheckNameHTTPUpstream}
 
 	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Get("https://www.google.com/robots.txt") //nolint:noctx // diagnostic check with timeout
@@ -597,7 +597,7 @@ func checkHTTPUpstream() CheckResult {
 
 // checkProxyEnvVars verifies HTTP_PROXY and HTTPS_PROXY are set in the guest.
 func checkProxyEnvVars(paths *config.Paths, user, ip, gateway string, httpPort int) CheckResult {
-	result := CheckResult{Name: "Proxy environment variables"}
+	result := CheckResult{Name: CheckNameProxyEnv}
 
 	expectedProxy := "http://" + net.JoinHostPort(gateway, strconv.Itoa(httpPort))
 
@@ -645,7 +645,7 @@ func checkProxyEnvVars(paths *config.Paths, user, ip, gateway string, httpPort i
 
 // checkDNSConfig verifies systemd-resolved is configured correctly in the guest.
 func checkDNSConfig(paths *config.Paths, user, ip, gateway string) CheckResult {
-	result := CheckResult{Name: "DNS configuration"}
+	result := CheckResult{Name: CheckNameDNSConfig}
 
 	// Check if the abox DNS config file exists
 	output, err := runSSHCommandOutput(paths, user, ip, "cat", "/etc/systemd/resolved.conf.d/00-abox.conf")

--- a/pkg/cmd/doctor/tui.go
+++ b/pkg/cmd/doctor/tui.go
@@ -297,7 +297,7 @@ func (m tuiModel) runPhase1() tea.Cmd {
 
 		// Check 1: Instance configuration
 		inst, paths, err := instance.LoadRequired(instanceName)
-		result := CheckResult{Name: "Instance configuration valid"}
+		result := CheckResult{Name: CheckNameConfig}
 		if err != nil {
 			result.Passed = false
 			result.Details = err.Error()
@@ -326,7 +326,7 @@ func (m tuiModel) runPhase1() tea.Cmd {
 
 		// Check 2: VM running
 		state := be.VM().State(instanceName)
-		vmResult := CheckResult{Name: "VM running"}
+		vmResult := CheckResult{Name: CheckNameVMRunning}
 		vmRunning := false
 		if state == backend.VMStateRunning {
 			vmResult.Passed = true
@@ -341,7 +341,7 @@ func (m tuiModel) runPhase1() tea.Cmd {
 
 		// Check 3: Network bridge
 		networkActive := be.Network().IsActive(inst.Bridge)
-		bridgeResult := CheckResult{Name: "Network bridge active"}
+		bridgeResult := CheckResult{Name: CheckNameBridge}
 		if networkActive {
 			bridgeResult.Passed = true
 			bridgeResult.Details = inst.Bridge
@@ -353,7 +353,7 @@ func (m tuiModel) runPhase1() tea.Cmd {
 		results = append(results, bridgeResult)
 
 		// Check 4: VM IP
-		ipResult := CheckResult{Name: "VM IP address"}
+		ipResult := CheckResult{Name: CheckNameVMIP}
 		var vmIP string
 		if vmRunning {
 			ip, err := instance.GetIP(inst, be.VM())
@@ -423,7 +423,7 @@ func runPhase2Cmd(instanceName string, inst *config.Instance, paths *config.Path
 // runPhase3Cmd returns a command that runs phase 3 checks.
 func runPhase3Cmd(inst *config.Instance, paths *config.Paths, vmIP string, vmRunning bool, dnsResult, httpResult CheckResult) tea.Cmd {
 	return func() tea.Msg {
-		result := CheckResult{Name: "SSH connection"}
+		result := CheckResult{Name: CheckNameSSH}
 		sshWorks := false
 		if vmRunning && vmIP != "" {
 			if testSSH(paths, inst.GetUser(), vmIP) {
@@ -452,7 +452,7 @@ func runPhase3Cmd(inst *config.Instance, paths *config.Paths, vmIP string, vmRun
 
 // checkInVMGateway checks whether the VM can reach its gateway.
 func checkInVMGateway(paths *config.Paths, inst *config.Instance, vmIP string, sshWorks bool) CheckResult {
-	result := CheckResult{Name: "Gateway reachable"}
+	result := CheckResult{Name: CheckNameGateway}
 	if !sshWorks {
 		result.Skipped = true
 		return result
@@ -469,7 +469,7 @@ func checkInVMGateway(paths *config.Paths, inst *config.Instance, vmIP string, s
 
 // checkInVMDNSResolve checks DNS resolution from inside the VM.
 func checkInVMDNSResolve(paths *config.Paths, inst *config.Instance, vmIP string, sshWorks bool, dnsResult CheckResult) CheckResult {
-	result := CheckResult{Name: "DNS resolution working"}
+	result := CheckResult{Name: CheckNameDNSResolve}
 	if !sshWorks || !dnsResult.Passed {
 		result.Skipped = true
 		return result
@@ -485,7 +485,7 @@ func checkInVMDNSResolve(paths *config.Paths, inst *config.Instance, vmIP string
 
 // checkInVMHTTPProxy checks HTTP proxy reachability from inside the VM.
 func checkInVMHTTPProxy(paths *config.Paths, inst *config.Instance, vmIP string, sshWorks bool, httpResult CheckResult) CheckResult {
-	result := CheckResult{Name: "HTTP proxy reachable"}
+	result := CheckResult{Name: CheckNameHTTPProxy}
 	if !sshWorks || !httpResult.Passed {
 		result.Skipped = true
 		return result
@@ -531,13 +531,13 @@ func runPhase4Cmd(instanceName string, inst *config.Instance, paths *config.Path
 			checkInVMGateway(paths, inst, vmIP, sshWorks),
 			checkInVMDNSResolve(paths, inst, vmIP, sshWorks, dnsResult),
 			checkInVMHTTPProxy(paths, inst, vmIP, sshWorks, httpResult),
-			skipOrRun("Guest disk space", sshWorks, func() CheckResult {
+			skipOrRun(CheckNameGuestDisk, sshWorks, func() CheckResult {
 				return checkGuestDiskSpace(paths, user, vmIP)
 			}),
-			skipOrRun("Proxy environment variables", sshWorks, func() CheckResult {
+			skipOrRun(CheckNameProxyEnv, sshWorks, func() CheckResult {
 				return checkProxyEnvVars(paths, user, vmIP, inst.Gateway, inst.HTTP.Port)
 			}),
-			skipOrRun("DNS configuration", sshWorks, func() CheckResult {
+			skipOrRun(CheckNameDNSConfig, sshWorks, func() CheckResult {
 				return checkDNSConfig(paths, user, vmIP, inst.Gateway)
 			}),
 		}

--- a/pkg/cmd/net/filter/filter.go
+++ b/pkg/cmd/net/filter/filter.go
@@ -40,7 +40,7 @@ Use 'abox net profile <instance> export' to get the captured domains.`,
   abox net filter dev active               # Block domains not in allowlist
   abox net filter dev passive              # Allow all, capture for profiling`,
 		Args:              cobra.RangeArgs(1, 2),
-		ValidArgsFunction: completion.Sequence(completion.RunningInstances(), completion.Values("active", "passive")),
+		ValidArgsFunction: completion.Sequence(completion.RunningInstances(), completion.Values(modeActive, modePassive)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Name = args[0]
 			if len(args) > 1 {
@@ -56,10 +56,16 @@ Use 'abox net profile <instance> export' to get the captured domains.`,
 	return cmd
 }
 
+// Filter mode names (CLI argument values).
+const (
+	modeActive  = "active"
+	modePassive = "passive"
+)
+
 // validModes are the allowed filter modes
 var validModes = map[string]bool{
-	"active":  true,
-	"passive": true,
+	modeActive:  true,
+	modePassive: true,
 }
 
 func runFilter(f *factory.Factory, name, mode string) error {
@@ -104,7 +110,7 @@ func runFilter(f *factory.Factory, name, mode string) error {
 		fmt.Fprintf(out, "  %s\n", httpResp.Message)
 	}
 
-	if mode == "passive" {
+	if mode == modePassive {
 		fmt.Fprintln(out)
 		fmt.Fprintln(out, "Passive mode: All requests allowed and captured for profiling.")
 		fmt.Fprintln(out, "Use 'abox net profile "+name+" export' to view captured domains.")
@@ -113,7 +119,7 @@ func runFilter(f *factory.Factory, name, mode string) error {
 	// Only log if we actually changed the mode
 	if mode != "" {
 		action := logging.ActionModeActive
-		if mode == "passive" {
+		if mode == modePassive {
 			action = logging.ActionModePassive
 		}
 		logging.AuditInstance(name, action)

--- a/pkg/cmd/net/profile/profile.go
+++ b/pkg/cmd/net/profile/profile.go
@@ -16,12 +16,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Profile subcommand names (CLI argument values, also sent over the
+// privilege RPC as ProfileReq.Subcommand).
+const (
+	subShow   = "show"
+	subExport = "export"
+	subClear  = "clear"
+	subCount  = "count"
+)
+
 // validSubcommands are the allowed profile subcommands.
 var validSubcommands = map[string]bool{
-	"show":   true,
-	"export": true,
-	"clear":  true,
-	"count":  true,
+	subShow:   true,
+	subExport: true,
+	subClear:  true,
+	subCount:  true,
 }
 
 // Options holds the options for the profile command.
@@ -61,7 +70,7 @@ Usage flow:
 		ValidArgsFunction: completion.Sequence(completion.RunningInstances()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Name = args[0]
-			opts.Subcommand = "show" // default
+			opts.Subcommand = subShow // default
 			if len(args) > 1 {
 				opts.Subcommand = args[1]
 			}
@@ -90,13 +99,13 @@ func runProfile(opts *Options, name, subcommand string) error {
 	factory.Ensure(&opts.Factory)
 
 	switch subcommand {
-	case "show":
+	case subShow:
 		return runShow(opts.Factory, name)
-	case "export":
+	case subExport:
 		return runExport(opts.Factory, name)
-	case "clear":
+	case subClear:
 		return runClear(opts, name)
-	case "count":
+	case subCount:
 		return runCount(opts.Factory, name)
 	default:
 		return fmt.Errorf("unknown subcommand: %s", subcommand)
@@ -108,7 +117,7 @@ func runShow(f *factory.Factory, name string) error {
 	var dnsErr, httpErr error
 
 	dnsErr = f.WithDNSClient(name, func(ctx context.Context, client rpc.DNSFilterClient) error {
-		resp, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: "show"})
+		resp, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: subShow})
 		if err != nil {
 			return err
 		}
@@ -117,7 +126,7 @@ func runShow(f *factory.Factory, name string) error {
 	})
 
 	httpErr = f.WithHTTPClient(name, func(ctx context.Context, client rpc.HTTPFilterClient) error {
-		resp, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: "show"})
+		resp, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: subShow})
 		if err != nil {
 			return err
 		}
@@ -162,7 +171,7 @@ func runExport(f *factory.Factory, name string) error {
 	var dnsErr, httpErr error
 
 	dnsErr = f.WithDNSClient(name, func(ctx context.Context, client rpc.DNSFilterClient) error {
-		resp, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: "show"})
+		resp, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: subShow})
 		if err != nil {
 			return err
 		}
@@ -171,7 +180,7 @@ func runExport(f *factory.Factory, name string) error {
 	})
 
 	httpErr = f.WithHTTPClient(name, func(ctx context.Context, client rpc.HTTPFilterClient) error {
-		resp, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: "show"})
+		resp, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: subShow})
 		if err != nil {
 			return err
 		}
@@ -223,12 +232,12 @@ func runClear(opts *Options, name string) error {
 	var dnsErr, httpErr error
 
 	dnsErr = opts.Factory.WithDNSClient(name, func(ctx context.Context, client rpc.DNSFilterClient) error {
-		_, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: "clear"})
+		_, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: subClear})
 		return err
 	})
 
 	httpErr = opts.Factory.WithHTTPClient(name, func(ctx context.Context, client rpc.HTTPFilterClient) error {
-		_, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: "clear"})
+		_, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: subClear})
 		return err
 	})
 
@@ -260,7 +269,7 @@ func runCount(f *factory.Factory, name string) error {
 	var dnsErr, httpErr error
 
 	dnsErr = f.WithDNSClient(name, func(ctx context.Context, client rpc.DNSFilterClient) error {
-		resp, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: "count"})
+		resp, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: subCount})
 		if err != nil {
 			return err
 		}
@@ -269,7 +278,7 @@ func runCount(f *factory.Factory, name string) error {
 	})
 
 	httpErr = f.WithHTTPClient(name, func(ctx context.Context, client rpc.HTTPFilterClient) error {
-		resp, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: "count"})
+		resp, err := client.Profile(ctx, &rpc.ProfileReq{Subcommand: subCount})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Clears all `golangci-lint v2.12.1` warnings on `main` and pins the CI lint
action to that version. CI was using `version: latest`; the linter drifted
between PR #5 (passing) and PR #7 (failing) and surfaced pre-existing
issues asynchronously. Pinning prevents the same trap from reappearing.

No behavior changes — every extracted const has the same byte-for-byte
string value as the literal it replaced (kernel hook names, Tetragon CRD
fields, RPC field values, SSH option strings, virsh state strings, doctor
check names shown in CLI/TUI output, and OS distro identifiers used in
CLI image selection).

## Scope note

The plan called out 58 issues (`50 goconst + 2 modernize + 6 nolintlint`),
which is the linter's _capped_ report — `golangci-lint` defaults to
`max-issues-per-linter=50` and `max-same-issues=3`, hiding the rest. With
caps disabled, the actual count was **97 issues (88 goconst, 7
nolintlint, 2 modernize)**. This PR fixes all of them so CI lint goes to
0 and the dependabot PRs (#5, #7) merge cleanly after auto-rebase.

## Commits

1. `chore: remove unused //nolint:gosec directives` — 7 dead directives
   (current `gosec` ruleset no longer flags these `unsafe.Pointer`-free fd
   conversions).
2. `chore: convert backward loops to slices.Backward` — both flagged
   loops in `internal/privilege/helper.go`.
3. `chore: extract OS distro and default-instance consts` — boxfile,
   config, and images packages.
4. `chore: extract log level and format consts` — `internal/logging` and
   `internal/validation`.
5. `chore: extract tetragon policy consts` — kprobe call names, action /
   operator / arg-type literals, and `TracingPolicy` CRD apiVersion/kind.
6. `chore: extract doctor check name consts` — `CheckName*` exported
   consts in `pkg/cmd/doctor/checks.go`, used in `doctor.go` and
   `tui.go`.
7. `chore: extract remaining goconst literals` — libvirt domstate
   strings, privilege RPC `pong` and `tcp`/`udp`, sshutil options,
   tetragon `sha256`, filtercmd `logs <instance>`, checkdeps install
   hint, net/filter modes, net/profile subcommands.
8. `ci: pin golangci-lint-action to v2.12.1` — root-cause fix.

## Follow-up (out of scope)

`Makefile`'s `lint` target runs bare `golangci-lint`, so contributors
running `make lint` may see different results than CI unless they install
the matching version. Worth pinning there too in a future PR.

## Test plan

- [x] `golangci-lint run --timeout 5m --max-issues-per-linter 0 --max-same-issues 0` → 0 issues
- [x] `make build` and `make build-helper` succeed
- [x] `make test` passes (no behavior changed)
- [ ] CI lint job passes on this branch
- [ ] Dependabot PRs #5 and #7 rebase cleanly afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)