### PR TITLE
build(deps): adopt Go 1.26 to resolve stdlib vuln findings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "^1"
+          go-version: "1.26"
           check-latest: true
           cache-dependency-path: go.sum
 
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "^1"
+          go-version: "1.26"
           check-latest: true
           cache-dependency-path: go.sum
 
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "^1"
+          go-version: "1.26"
           check-latest: true
           cache-dependency-path: go.sum
 
@@ -75,7 +75,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "^1"
+          go-version: "1.26"
           check-latest: true
           cache-dependency-path: go.sum
 
@@ -93,7 +93,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "^1"
+          go-version: "1.26"
           check-latest: true
           cache-dependency-path: go.sum
 
@@ -110,7 +110,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "^1"
+          go-version: "1.26"
           check-latest: true
           cache-dependency-path: go.sum
 
@@ -125,7 +125,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "^1"
+          go-version: "1.26"
           check-latest: true
           cache-dependency-path: go.sum
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "^1"
+          go-version: "1.26"
           check-latest: true
           cache-dependency-path: go.sum
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ abox down --remove       # Stop and delete
 
 ## Installation
 
-**Requirements:** Linux with KVM/libvirt, Go 1.25+
+**Requirements:** Linux with KVM/libvirt, Go 1.26+
 
 ```bash
 # Debian/Ubuntu

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sandialabs/abox
 
-go 1.25.0
+go 1.26.0
 
 require (
 	charm.land/bubbletea/v2 v2.0.6


### PR DESCRIPTION
## Summary

Resolves the two remaining `govulncheck` standard-library findings, both fixed in **go1.26.4**:

- **GO-2026-5039** — `net/textproto` includes unescaped arbitrary input in errors (reached via `internal/images/images.go:263`)
- **GO-2026-5037** — `crypto/x509` inefficient candidate hostname parsing (reached via `internal/httpfilter/proxy.go:152` and `pkg/cmdutil/jqwriter.go:75`)

These are **toolchain** vulns, not dependency vulns — there's no source fix; the resolution is building with go1.26.4+. This is the follow-up explicitly deferred in `d5862c8` (*"the net/http stdlib portion needs a go1.26.3 toolchain bump, deferred"*).

## Approach

Rather than pin a `toolchain` directive (which would require a manual bump on every future stdlib CVE), this narrows CI's setup-go constraint `"^1"` → `"1.26"` (keeping `check-latest: true`). The `Govulncheck` gate then auto-tracks the latest **1.26.x** patch (currently 1.26.4) and clears these with **zero recurring maintenance**. `"1.26"` also stops surprise jumps to 1.27+ (which previously pulled in lint churn). The `go.mod` floor is raised to `go 1.26.0` and the README requirement to `Go 1.26+` to match.

| File | Change |
|------|--------|
| `go.mod` | `go 1.25.0` → `go 1.26.0` |
| `.github/workflows/ci.yaml` | all 7 setup-go steps `"^1"` → `"1.26"` |
| `.github/workflows/release.yaml` | setup-go `"^1"` → `"1.26"` |
| `README.md` | `Go 1.25+` → `Go 1.26+` |

No `go.sum` change, no `toolchain` directive.

## Verification

Under go1.26.4:
- `govulncheck ./...` → **No vulnerabilities found**
- `go build ./...`, `go vet ./...`, `go test -race ./...` → all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)