### PR TITLE
fix(httpfilter): restore http_proxy/https_proxy/no_proxy support

### DIFF
--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -101,6 +101,20 @@ origins. Per-request filtering (allowlist, SSRF, domain fronting) applies
 identically to both protocols, so gRPC-based tools (including
 [dolt](https://github.com/dolthub/dolt)) work through the proxy.
 
+### Upstream proxy chaining
+
+When the host itself sits behind a proxy, httpfilter honors the standard
+`http_proxy`, `https_proxy`, and `no_proxy` environment variables from the
+daemon's environment (inherited from the shell that ran `abox start`).
+Proxy URLs may use the `http://`, `https://`, `socks5://`, or `socks5h://`
+schemes. Forwarded and MITM'd requests are sent via the upstream proxy, and
+non-MITM CONNECT tunnels chain through it (HTTP CONNECT or a SOCKS5 handshake,
+per the scheme). Allowlist and SSRF policy still apply to the requested
+target — the proxy hop never relaxes filtering.
+
+Note these are distinct from the proxy variables *inside* the VM, which point
+the guest at abox's own httpfilter.
+
 ### HTTP/HTTPS Request Flow
 
 ```mermaid

--- a/internal/httpfilter/proxy.go
+++ b/internal/httpfilter/proxy.go
@@ -34,6 +34,7 @@ const (
 const (
 	protoHTTP11 = "http/1.1" // ALPN protocol id for HTTP/1.1
 	schemeHTTP  = "http"     // URL scheme and traffic-logger label
+	schemeHTTPS = "https"    // URL scheme
 )
 
 // requestDecision is the verdict for a fully-parsed inbound request (forward
@@ -215,7 +216,7 @@ func (h *handler) requestHandler(connectTarget string) http.Handler {
 		// requests; the reverse proxy needs them populated.
 		if r.URL.Scheme == "" {
 			if connectTarget != "" {
-				r.URL.Scheme = "https"
+				r.URL.Scheme = schemeHTTPS
 			} else {
 				r.URL.Scheme = schemeHTTP
 			}
@@ -244,11 +245,12 @@ func (h *handler) requestHandler(connectTarget string) http.Handler {
 // in-flight tunnels. The outer server's WriteTimeout is cleared after Hijack
 // for the same reason as intercept.
 func (h *handler) tunnel(w http.ResponseWriter, r *http.Request) {
-	// DialContext (not DialTimeout) so Shutdown cancels a slow dial promptly via
-	// hijackCtx — the dial runs before trackConn, so it is otherwise uncounted.
-	dialer := &net.Dialer{Timeout: 30 * time.Second}
-	upstream, err := dialer.DialContext(h.s.hijackCtx, "tcp", r.Host)
+	// hijackCtx-aware dial so Shutdown cancels a slow dial promptly — the dial
+	// runs before trackConn, so it is otherwise uncounted. Routed through
+	// dialUpstreamTunnel so an upstream proxy (https_proxy) is honored.
+	upstream, err := h.s.dialUpstreamTunnel(h.s.hijackCtx, r.Host)
 	if err != nil {
+		logging.Debug("tunnel upstream dial failed", "host", r.Host, "err", err)
 		http.Error(w, "Bad gateway", http.StatusBadGateway)
 		return
 	}

--- a/internal/httpfilter/server.go
+++ b/internal/httpfilter/server.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -19,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/net/http/httpproxy"
 	"golang.org/x/net/http2"
 
 	"github.com/sandialabs/abox/internal/allowlist"
@@ -51,6 +53,12 @@ type Server struct {
 	listener     net.Listener
 	proxyHandler http.Handler
 	transport    *http.Transport
+	// proxyForURL resolves the upstream proxy for a target URL, captured once
+	// in NewServer from http_proxy/https_proxy/no_proxy. Both the transport
+	// path and the non-MITM tunnel path consult it; nil result = dial direct.
+	// Tests inject a fake before Start (httpproxy never proxies loopback, so
+	// env vars can't drive the proxied path against 127.0.0.1 origins).
+	proxyForURL  func(*url.URL) (*url.URL, error)
 	reverseProxy *httputil.ReverseProxy
 	http1Server  *http.Server  // used as BaseConfig for h2 and as the per-conn http.Server template for h1
 	http2Server  *http2.Server // h2 server for intercepted MITM connections
@@ -135,7 +143,11 @@ func NewServer(filter *allowlist.Filter, passive bool) *Server {
 	}
 	s.SetActive(!passive)
 
+	// httpproxy.FromEnvironment (not http.ProxyFromEnvironment) because the
+	// stdlib func caches the environment in a package-level sync.Once.
+	s.proxyForURL = httpproxy.FromEnvironment().ProxyFunc()
 	s.transport = &http.Transport{
+		Proxy:                 func(r *http.Request) (*url.URL, error) { return s.proxyForURL(r.URL) },
 		DialContext:           (&net.Dialer{Timeout: 30 * time.Second}).DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,

--- a/internal/httpfilter/upstream.go
+++ b/internal/httpfilter/upstream.go
@@ -1,0 +1,265 @@
+// Upstream-proxy chaining for the non-MITM CONNECT tunnel path.
+//
+// The transport path (forward + post-MITM requests) gets upstream-proxy
+// support from http.Transport.Proxy; this file provides the equivalent for
+// tunnel(), which works at the raw-conn level: when proxyForURL selects an
+// upstream proxy for the CONNECT target, we dial the proxy and chain a
+// CONNECT through it instead of dialing the target directly.
+
+package httpfilter
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"golang.org/x/net/proxy"
+)
+
+const (
+	schemeSOCKS5  = "socks5"
+	schemeSOCKS5H = "socks5h"
+)
+
+// connectExchangeTimeout bounds the CONNECT request/response exchange with an
+// upstream proxy. Matches the dial timeout used throughout this package.
+const connectExchangeTimeout = 30 * time.Second
+
+// maxProxyResponseHeader bounds the upstream proxy's CONNECT response headers
+// (a conservative bound; stdlib Transport allows up to 10 MiB), so a broken or
+// hostile proxy can't feed unbounded data before the tunnel is established.
+const maxProxyResponseHeader = 1 << 20
+
+// dialUpstreamTunnel opens a TCP conn to target ("host:port"), either directly
+// or — when proxyForURL selects an upstream proxy for https://target — through
+// that proxy (chained CONNECT for http/https proxies, SOCKS5 otherwise).
+// CONNECT targets carry https semantics (https_proxy governs), matching
+// goproxy's old env-based ConnectDial.
+func (s *Server) dialUpstreamTunnel(ctx context.Context, target string) (net.Conn, error) {
+	proxyURL, err := s.proxyForURL(&url.URL{Scheme: schemeHTTPS, Host: target})
+	if err != nil {
+		return nil, err
+	}
+	dialer := &net.Dialer{Timeout: 30 * time.Second}
+	if proxyURL == nil {
+		return dialer.DialContext(ctx, "tcp", target)
+	}
+	// Same scheme set the transport path supports (http.Transport.Proxy).
+	switch proxyURL.Scheme {
+	case schemeHTTP, schemeHTTPS:
+		return dialViaConnect(ctx, dialer, proxyURL, target)
+	case schemeSOCKS5, schemeSOCKS5H:
+		return dialViaSOCKS5(ctx, dialer, proxyURL, target)
+	default:
+		return nil, fmt.Errorf("unsupported proxy scheme %q", proxyURL.Scheme)
+	}
+}
+
+// proxyAddr returns the dialable "host:port" for a proxy URL, defaulting the
+// port from the scheme. Built from Hostname/Port (not URL.Host) so IPv6
+// literal proxies re-bracket correctly.
+func proxyAddr(proxyURL *url.URL) string {
+	port := proxyURL.Port()
+	if port == "" {
+		switch proxyURL.Scheme {
+		case schemeHTTPS:
+			port = "443"
+		case schemeSOCKS5, schemeSOCKS5H:
+			port = "1080"
+		default:
+			port = "80"
+		}
+	}
+	return net.JoinHostPort(proxyURL.Hostname(), port)
+}
+
+// dialViaConnect dials proxyURL, sends "CONNECT target" (with basic
+// Proxy-Authorization when proxyURL has userinfo), validates the 200 response,
+// and returns a conn positioned at the start of the tunnel byte stream.
+func dialViaConnect(ctx context.Context, dialer *net.Dialer, proxyURL *url.URL, target string) (net.Conn, error) {
+	conn, err := dialer.DialContext(ctx, "tcp", proxyAddr(proxyURL))
+	if err != nil {
+		return nil, err
+	}
+
+	// Bound everything up to the established tunnel — the TLS handshake to an
+	// https proxy AND the CONNECT exchange — with a deadline, and force it to
+	// fail fast if ctx is canceled mid-flight (Shutdown cancels hijackCtx);
+	// the deadline alone would hold the CONNECT handler for up to 30s.
+	// The poke goes through `raw`, never reassigned: the AfterFunc closure
+	// runs on its own goroutine, so poking `conn` (reassigned to the tls.Conn
+	// below) would race that write. Deadlines on the raw conn pass through
+	// tls.Conn, so targeting raw is equivalent.
+	raw := conn
+	_ = raw.SetDeadline(time.Now().Add(connectExchangeTimeout))
+	stop := context.AfterFunc(ctx, func() { _ = raw.SetDeadline(time.Unix(1, 0)) })
+	defer stop()
+
+	if proxyURL.Scheme == schemeHTTPS {
+		tlsConn := tls.Client(conn, &tls.Config{
+			ServerName: proxyURL.Hostname(),
+			MinVersion: tls.VersionTLS12,
+		})
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("proxy TLS handshake: %w", err)
+		}
+		conn = tlsConn
+	}
+
+	req := "CONNECT " + target + " HTTP/1.1\r\nHost: " + target + "\r\n"
+	if u := proxyURL.User; u != nil {
+		pass, _ := u.Password()
+		cred := base64.StdEncoding.EncodeToString([]byte(u.Username() + ":" + pass))
+		req += "Proxy-Authorization: Basic " + cred + "\r\n"
+	}
+	req += "\r\n"
+	if _, err := io.WriteString(conn, req); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("proxy CONNECT write: %w", err)
+	}
+
+	br := bufio.NewReader(io.LimitReader(conn, maxProxyResponseHeader))
+	// resp.Body is deliberately never read or closed: CONNECT is not in
+	// stdlib's noResponseBodyExpected set, so a 200 without Content-Length
+	// gets a read-until-EOF body whose Close would drain live tunnel bytes.
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodConnect}) //nolint:bodyclose // see comment above
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("proxy CONNECT response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		_ = conn.Close()
+		return nil, fmt.Errorf("proxy CONNECT refused: %s", resp.Status)
+	}
+
+	// Stop the cancellation poke BEFORE clearing the deadline. The reverse
+	// order would let a ctx cancellation land between the clear and the stop,
+	// poisoning a conn we are about to return as live with a past deadline.
+	// stop()==false means the poke fired (ctx is done): the tunnel is being
+	// torn down, so fail rather than return a poisoned conn.
+	if !stop() {
+		_ = conn.Close()
+		return nil, ctx.Err()
+	}
+	_ = raw.SetDeadline(time.Time{})
+
+	// The reader may have buffered tunnel bytes past the response headers
+	// (server-speaks-first protocols, or a proxy that coalesces writes).
+	// Stdlib can discard its reader because the transport always speaks TLS
+	// next; a raw tunnel cannot.
+	if n := br.Buffered(); n > 0 {
+		peeked, err := br.Peek(n)
+		if err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("proxy CONNECT buffered bytes: %w", err)
+		}
+		// Copy: the peeked slice aliases the bufio buffer.
+		buffered := append([]byte(nil), peeked...)
+		return &prefixConn{
+			Conn: conn,
+			r:    io.MultiReader(bytes.NewReader(buffered), conn),
+		}, nil
+	}
+	return conn, nil
+}
+
+// dialViaSOCKS5 dials target through a SOCKS5 proxy, with username/password
+// auth when proxyURL has userinfo. The target hostname is sent to the proxy
+// for resolution (socks5h semantics) for both schemes, matching
+// net/http.Transport's treatment of socks5 proxy URLs.
+func dialViaSOCKS5(ctx context.Context, dialer *net.Dialer, proxyURL *url.URL, target string) (net.Conn, error) {
+	var auth *proxy.Auth
+	if u := proxyURL.User; u != nil {
+		pass, _ := u.Password()
+		auth = &proxy.Auth{User: u.Username(), Password: pass}
+	}
+	fwd := &socksForwardDialer{d: dialer}
+	d, err := proxy.SOCKS5("tcp", proxyAddr(proxyURL), auth, fwd)
+	if err != nil {
+		return nil, fmt.Errorf("socks5 proxy: %w", err)
+	}
+	cd, ok := d.(proxy.ContextDialer)
+	if !ok {
+		// proxy.SOCKS5 always returns a ContextDialer today; defensive so a
+		// future x/net change degrades loudly instead of hanging Shutdown.
+		return nil, errors.New("socks5 dialer does not support context cancellation")
+	}
+	// The socks client derives its handshake I/O deadline from ctx.Deadline()
+	// (and watches ctx.Done() for cancellation); ctx here is hijackCtx, which
+	// has no deadline, so bound the handshake explicitly — same rationale as
+	// the CONNECT exchange deadline in dialViaConnect.
+	dialCtx, cancel := context.WithTimeout(ctx, connectExchangeTimeout)
+	defer cancel()
+	conn, err := cd.DialContext(dialCtx, "tcp", target)
+	if err != nil {
+		return nil, fmt.Errorf("socks5 dial: %w", err)
+	}
+	// x/net's socks conn embeds the net.Conn interface, so the TCP conn's
+	// CloseWrite is not promoted and the tunnel splice's halfCloser assertion
+	// would fail — half-close would silently stop propagating through socks5
+	// tunnels. Restore it via the raw conn the forward dialer recorded.
+	return &socksConn{Conn: conn, raw: fwd.raw}, nil
+}
+
+// socksForwardDialer is the forward dialer handed to proxy.SOCKS5. It records
+// the raw TCP conn it dials so dialViaSOCKS5 can restore CloseWrite on the
+// returned socks conn. Single-use: one dial per dialViaSOCKS5 call, and the
+// socks handshake completes before DialContext returns, so `raw` is never
+// accessed concurrently.
+type socksForwardDialer struct {
+	d   *net.Dialer
+	raw net.Conn
+}
+
+func (f *socksForwardDialer) Dial(network, addr string) (net.Conn, error) {
+	return f.DialContext(context.Background(), network, addr)
+}
+
+func (f *socksForwardDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	conn, err := f.d.DialContext(ctx, network, addr)
+	f.raw = conn
+	return conn, err
+}
+
+// socksConn is a net.Conn that restores the write-side half-close hidden by
+// x/net's socks conn, delegating CloseWrite to the raw conn beneath it (like
+// trackedConn/limitedConn/prefixConn) so the tunnel's half-close survives.
+type socksConn struct {
+	net.Conn          // the socks conn: Read/Write/Close
+	raw      net.Conn // the TCP conn beneath it
+}
+
+func (c *socksConn) CloseWrite() error {
+	if cw, ok := c.raw.(halfCloser); ok {
+		return cw.CloseWrite()
+	}
+	return nil
+}
+
+// prefixConn is a net.Conn whose Read first drains bytes buffered during the
+// CONNECT response parse, then continues from the conn. CloseWrite is
+// delegated (like trackedConn/limitedConn) so the tunnel's half-close
+// survives the wrapper.
+type prefixConn struct {
+	net.Conn
+	r io.Reader
+}
+
+func (c *prefixConn) Read(p []byte) (int, error) { return c.r.Read(p) }
+
+func (c *prefixConn) CloseWrite() error {
+	if cw, ok := c.Conn.(halfCloser); ok {
+		return cw.CloseWrite()
+	}
+	return nil
+}

--- a/internal/httpfilter/upstream_test.go
+++ b/internal/httpfilter/upstream_test.go
@@ -1,0 +1,739 @@
+package httpfilter
+
+import (
+	"bufio"
+	"context"
+	"crypto/x509"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sandialabs/abox/internal/allowlist"
+	"github.com/sandialabs/abox/internal/cert"
+)
+
+// upstreamRecorder collects the targets a test upstream proxy was asked to
+// reach: "CONNECT host:port" for tunnels, the absolute URL for forward requests.
+type upstreamRecorder struct {
+	mu      sync.Mutex
+	targets []string
+}
+
+func (r *upstreamRecorder) add(t string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.targets = append(r.targets, t)
+}
+
+func (r *upstreamRecorder) get() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.targets...)
+}
+
+// startTestUpstreamProxy runs a minimal recording forward proxy standing in
+// for a corporate proxy. CONNECT requests are checked against wantAuth (407 on
+// mismatch when set), recorded, answered with exactly "200 OK", then spliced
+// byte-for-byte. Absolute-URI requests are recorded and round-tripped with a
+// plain client. Returns the proxy URL and the recorder.
+func startTestUpstreamProxy(t *testing.T, wantAuth string) (*url.URL, *upstreamRecorder) {
+	t.Helper()
+	rec := &upstreamRecorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if wantAuth != "" && r.Header.Get("Proxy-Authorization") != wantAuth {
+			w.Header().Set("Proxy-Authenticate", "Basic")
+			http.Error(w, "auth required", http.StatusProxyAuthRequired)
+			return
+		}
+		if r.Method == http.MethodConnect {
+			rec.add("CONNECT " + r.Host)
+			upstream, err := net.DialTimeout("tcp", r.Host, 5*time.Second)
+			if err != nil {
+				http.Error(w, "bad gateway", http.StatusBadGateway)
+				return
+			}
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				_ = upstream.Close()
+				http.Error(w, "no hijack", http.StatusInternalServerError)
+				return
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				_ = upstream.Close()
+				return
+			}
+			_ = conn.SetDeadline(time.Time{})
+			_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\n\r\n"))
+			go func() { _, _ = io.Copy(upstream, conn); _ = upstream.Close() }()
+			_, _ = io.Copy(conn, upstream)
+			_ = conn.Close()
+			return
+		}
+		if !r.URL.IsAbs() {
+			http.Error(w, "not a proxy request", http.StatusBadRequest)
+			return
+		}
+		rec.add(r.URL.String())
+		out, err := http.NewRequestWithContext(r.Context(), r.Method, r.URL.String(), r.Body)
+		if err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		resp, err := http.DefaultTransport.RoundTrip(out)
+		if err != nil {
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+	}))
+	t.Cleanup(srv.Close)
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse upstream proxy URL: %v", err)
+	}
+	return u, rec
+}
+
+// injectUpstreamProxy points a not-yet-started Server's proxy resolution at
+// upstreamURL for every target. Injection (rather than env vars) is required
+// because httpproxy never proxies loopback targets, and all test origins are
+// loopback.
+func injectUpstreamProxy(server *Server, upstreamURL *url.URL) {
+	server.proxyForURL = func(*url.URL) (*url.URL, error) { return upstreamURL, nil }
+}
+
+// testProxyViaUpstream mirrors testProxy but injects the upstream proxy
+// before Start.
+func testProxyViaUpstream(t *testing.T, upstreamCA *x509.CertPool, upstreamURL *url.URL) (caPEM []byte, proxyURL *url.URL) {
+	t.Helper()
+	caCertPEM, caKeyPEM, err := cert.GenerateCA("test-ca")
+	if err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+	tmpDir := t.TempDir()
+	cp := filepath.Join(tmpDir, "ca.pem")
+	kp := filepath.Join(tmpDir, "key.pem")
+	_ = os.WriteFile(cp, caCertPEM, 0o644)
+	_ = os.WriteFile(kp, caKeyPEM, 0o600)
+
+	filter := allowlist.NewFilter()
+	filter.Add("127.0.0.1")
+	server := NewServer(filter, false)
+	if err := server.LoadCA(cp, kp); err != nil {
+		t.Fatalf("LoadCA: %v", err)
+	}
+	if upstreamCA != nil {
+		server.transport.TLSClientConfig.RootCAs = upstreamCA
+	}
+	injectUpstreamProxy(server, upstreamURL)
+	if err := server.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+	return caCertPEM, &url.URL{Scheme: "http", Host: server.listener.Addr().String()}
+}
+
+func TestUpstream_ForwardProxy_HTTP1(t *testing.T) {
+	// Plain-HTTP forward request must traverse the upstream proxy as an
+	// absolute-URI request.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "hello from upstream")
+	}))
+	defer ts.Close()
+	tsHost := strings.TrimPrefix(ts.URL, "http://")
+
+	upURL, rec := startTestUpstreamProxy(t, "")
+	_, proxyURL := testProxyViaUpstream(t, nil, upURL)
+
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+	resp, err := client.Get("http://" + tsHost + "/foo")
+	if err != nil {
+		t.Fatalf("GET via proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK || string(body) != "hello from upstream" {
+		t.Errorf("status=%d body=%q, want 200 %q", resp.StatusCode, body, "hello from upstream")
+	}
+
+	targets := rec.get()
+	if len(targets) != 1 || !strings.Contains(targets[0], tsHost+"/foo") {
+		t.Errorf("upstream proxy saw %v, want one absolute URL for %s/foo", targets, tsHost)
+	}
+}
+
+func TestUpstream_Intercept_HTTP1(t *testing.T) {
+	// MITM'd HTTPS request: abox's transport must CONNECT through the upstream
+	// proxy, then speak TLS to the origin inside that tunnel.
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "hello h1")
+	}))
+	defer ts.Close()
+
+	upURL, rec := startTestUpstreamProxy(t, "")
+	caPEM, proxyURL := testProxyViaUpstream(t, originCAPool(ts), upURL)
+
+	client := clientTrustingAboxCA(t, caPEM, proxyURL, false)
+	resp, err := client.Get(ts.URL + "/path")
+	if err != nil {
+		t.Fatalf("GET via proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK || string(body) != "hello h1" {
+		t.Errorf("status=%d body=%q, want 200 %q", resp.StatusCode, body, "hello h1")
+	}
+
+	tsHost := strings.TrimPrefix(ts.URL, "https://")
+	targets := rec.get()
+	if len(targets) != 1 || targets[0] != "CONNECT "+tsHost {
+		t.Errorf("upstream proxy saw %v, want [CONNECT %s]", targets, tsHost)
+	}
+}
+
+func TestUpstream_Intercept_HTTP2(t *testing.T) {
+	// Same as the h1 case but with an h2 origin: proves ALPN negotiation
+	// composes with CONNECT-through-upstream-proxy.
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "hello h2")
+	}))
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	defer ts.Close()
+
+	upURL, rec := startTestUpstreamProxy(t, "")
+	caPEM, proxyURL := testProxyViaUpstream(t, originCAPool(ts), upURL)
+
+	client := clientTrustingAboxCA(t, caPEM, proxyURL, true)
+	resp, err := client.Get(ts.URL + "/path")
+	if err != nil {
+		t.Fatalf("GET via proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK || string(body) != "hello h2" {
+		t.Errorf("status=%d body=%q, want 200 %q", resp.StatusCode, body, "hello h2")
+	}
+	if resp.ProtoMajor != 2 {
+		t.Errorf("response ProtoMajor = %d, want 2", resp.ProtoMajor)
+	}
+	if targets := rec.get(); len(targets) != 1 || !strings.HasPrefix(targets[0], "CONNECT ") {
+		t.Errorf("upstream proxy saw %v, want one CONNECT", targets)
+	}
+}
+
+// rawConnectThroughAbox opens a raw client conn to a tunnel-mode abox server,
+// performs the CONNECT to target, and returns the conn + reader positioned
+// at the tunnel start. Fails the test on any error or non-wantStatus reply.
+func rawConnectThroughAbox(t *testing.T, server *Server, target string, wantStatus int) (net.Conn, *bufio.Reader) {
+	t.Helper()
+	c, err := net.DialTimeout("tcp", server.listener.Addr().String(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial abox proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	if _, err := c.Write([]byte("CONNECT " + target + " HTTP/1.1\r\nHost: " + target + "\r\n\r\n")); err != nil {
+		t.Fatalf("write CONNECT: %v", err)
+	}
+	br := bufio.NewReader(c)
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if resp.StatusCode != wantStatus {
+		t.Fatalf("CONNECT status = %d, want %d", resp.StatusCode, wantStatus)
+	}
+	return c, br
+}
+
+// tunnelEchoServer is a plain-TCP upstream that echoes one byte uppercased.
+func tunnelEchoServer(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 1)
+				if _, err := c.Read(buf); err != nil {
+					return
+				}
+				buf[0] -= 'a' - 'A'
+				_, _ = c.Write(buf)
+			}(c)
+		}
+	}()
+	return ln
+}
+
+// tunnelModeServer returns a started Server with no MITM CA (CONNECT →
+// actionTunnel) and 127.0.0.1 allowlisted.
+func tunnelModeServer(t *testing.T) *Server {
+	t.Helper()
+	filter := allowlist.NewFilter()
+	filter.Add("127.0.0.1")
+	server := NewServer(filter, false)
+	return server
+}
+
+func startTunnelModeServer(t *testing.T, server *Server) {
+	t.Helper()
+	if err := server.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+}
+
+func TestUpstream_Tunnel_ChainsConnect(t *testing.T) {
+	// Non-MITM tunnel must chain CONNECT through the upstream proxy instead of
+	// dialing the target directly.
+	ln := tunnelEchoServer(t)
+	target := ln.Addr().String()
+
+	upURL, rec := startTestUpstreamProxy(t, "")
+	server := tunnelModeServer(t)
+	injectUpstreamProxy(server, upURL)
+	startTunnelModeServer(t, server)
+
+	c, br := rawConnectThroughAbox(t, server, target, http.StatusOK)
+	if _, err := c.Write([]byte("a")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, 1)
+	if _, err := io.ReadFull(br, got); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if got[0] != 'A' {
+		t.Errorf("tunnel echo = %q, want %q", got, "A")
+	}
+	if targets := rec.get(); len(targets) != 1 || targets[0] != "CONNECT "+target {
+		t.Errorf("upstream proxy saw %v, want [CONNECT %s]", targets, target)
+	}
+}
+
+func TestUpstream_Tunnel_ProxyAuth(t *testing.T) {
+	// A userinfo'd proxy URL must produce a basic Proxy-Authorization header on
+	// the chained CONNECT. The fake proxy 407s on mismatch, so a missing or
+	// wrong header fails deterministically (502 from abox).
+	ln := tunnelEchoServer(t)
+	target := ln.Addr().String()
+
+	upURL, rec := startTestUpstreamProxy(t, "Basic dTpw") // base64("u:p")
+	authURL := *upURL
+	authURL.User = url.UserPassword("u", "p")
+
+	server := tunnelModeServer(t)
+	injectUpstreamProxy(server, &authURL)
+	startTunnelModeServer(t, server)
+
+	c, br := rawConnectThroughAbox(t, server, target, http.StatusOK)
+	if _, err := c.Write([]byte("b")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, 1)
+	if _, err := io.ReadFull(br, got); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if got[0] != 'B' {
+		t.Errorf("tunnel echo = %q, want %q", got, "B")
+	}
+	if targets := rec.get(); len(targets) != 1 || targets[0] != "CONNECT "+target {
+		t.Errorf("upstream proxy saw %v, want [CONNECT %s]", targets, target)
+	}
+}
+
+func TestUpstream_Tunnel_ProxyRefuses_502(t *testing.T) {
+	// Upstream proxy refusing the CONNECT (407 here — any non-200) must surface
+	// to the client as 502 from abox.
+	ln := tunnelEchoServer(t)
+	target := ln.Addr().String()
+
+	upURL, _ := startTestUpstreamProxy(t, "Basic dTpw")
+	server := tunnelModeServer(t)
+	injectUpstreamProxy(server, upURL) // no userinfo → 407 from the fake proxy
+	startTunnelModeServer(t, server)
+
+	rawConnectThroughAbox(t, server, target, http.StatusBadGateway)
+}
+
+func TestUpstream_DialUpstreamTunnel_NilProxyDialsDirect(t *testing.T) {
+	// proxyForURL returning (nil, nil) — no proxy env, no_proxy match, or
+	// loopback — must fall through to a direct dial.
+	ln := tunnelEchoServer(t)
+	server := tunnelModeServer(t)
+	server.proxyForURL = func(*url.URL) (*url.URL, error) { return nil, nil } //nolint:nilnil // httpproxy semantics: nil URL = dial direct
+
+	conn, err := server.dialUpstreamTunnel(context.Background(), ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dialUpstreamTunnel: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte("c")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, 1)
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got[0] != 'C' {
+		t.Errorf("echo = %q, want %q", got, "C")
+	}
+}
+
+func TestUpstream_NewServer_CapturesEnv(t *testing.T) {
+	// NewServer must capture http_proxy/https_proxy/no_proxy at construction.
+	// Safe with t.Setenv because httpproxy.FromEnvironment reads env at call
+	// time (unlike http.ProxyFromEnvironment's process-wide sync.Once).
+	t.Setenv("HTTP_PROXY", "http://corp:3128")
+	t.Setenv("HTTPS_PROXY", "http://corp:3128")
+	t.Setenv("NO_PROXY", "internal.test")
+
+	server := NewServer(allowlist.NewFilter(), false)
+
+	proxied, err := server.proxyForURL(&url.URL{Scheme: "https", Host: "example.com:443"})
+	if err != nil {
+		t.Fatalf("proxyForURL: %v", err)
+	}
+	if proxied == nil || proxied.Host != "corp:3128" {
+		t.Errorf("proxyForURL(example.com) = %v, want http://corp:3128", proxied)
+	}
+
+	direct, err := server.proxyForURL(&url.URL{Scheme: "https", Host: "internal.test:443"})
+	if err != nil {
+		t.Fatalf("proxyForURL: %v", err)
+	}
+	if direct != nil {
+		t.Errorf("proxyForURL(internal.test) = %v, want nil (no_proxy)", direct)
+	}
+}
+
+func TestUpstream_DialViaConnect_BufferedBytesPreserved(t *testing.T) {
+	// A proxy that coalesces the CONNECT 200 with early tunnel bytes (e.g. a
+	// server-speaks-first protocol relayed eagerly) must not lose those bytes:
+	// dialViaConnect wraps the conn so buffered data is read first.
+	const early = "EARLY-TUNNEL-BYTES"
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		// Read the CONNECT request headers (up to the blank line).
+		br := bufio.NewReader(c)
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if line == "\r\n" {
+				break
+			}
+		}
+		// Coalesce the 200 with early tunnel bytes in one write.
+		_, _ = c.Write([]byte("HTTP/1.1 200 OK\r\n\r\n" + early))
+	}()
+
+	proxyURL := &url.URL{Scheme: "http", Host: ln.Addr().String()}
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	conn, err := dialViaConnect(context.Background(), dialer, proxyURL, "ignored.test:443")
+	if err != nil {
+		t.Fatalf("dialViaConnect: %v", err)
+	}
+	defer conn.Close()
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	got := make([]byte, len(early))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("read early bytes: %v", err)
+	}
+	if string(got) != early {
+		t.Errorf("early tunnel bytes = %q, want %q", got, early)
+	}
+}
+
+func TestUpstream_DialUpstreamTunnel_UnsupportedScheme(t *testing.T) {
+	server := tunnelModeServer(t)
+	badURL := &url.URL{Scheme: "socks4", Host: "127.0.0.1:1080"}
+	injectUpstreamProxy(server, badURL)
+	_, err := server.dialUpstreamTunnel(context.Background(), "x:443")
+	if err == nil || !strings.Contains(err.Error(), "unsupported proxy scheme") {
+		t.Errorf("err = %v, want unsupported proxy scheme", err)
+	}
+}
+
+// startTestSOCKS5Proxy runs a minimal recording SOCKS5 proxy (RFC 1928/1929).
+// When wantUser is "", only the no-auth method is offered; otherwise
+// username/password auth is required and verified. CONNECT targets are
+// recorded as "SOCKS5 host:port". The returned URL carries userinfo when auth
+// is configured.
+func startTestSOCKS5Proxy(t *testing.T, wantUser, wantPass string) (*url.URL, *upstreamRecorder) {
+	t.Helper()
+	rec := &upstreamRecorder{}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go serveSOCKS5Conn(c, rec, wantUser, wantPass)
+		}
+	}()
+	u := &url.URL{Scheme: "socks5", Host: ln.Addr().String()}
+	if wantUser != "" {
+		u.User = url.UserPassword(wantUser, wantPass)
+	}
+	return u, rec
+}
+
+func serveSOCKS5Conn(c net.Conn, rec *upstreamRecorder, wantUser, wantPass string) {
+	defer c.Close()
+	br := bufio.NewReader(c)
+
+	// Greeting: VER NMETHODS METHODS...
+	hdr := make([]byte, 2)
+	if _, err := io.ReadFull(br, hdr); err != nil || hdr[0] != 5 {
+		return
+	}
+	methods := make([]byte, hdr[1])
+	if _, err := io.ReadFull(br, methods); err != nil {
+		return
+	}
+	if wantUser != "" {
+		// Require username/password (method 2), RFC 1929 subnegotiation.
+		_, _ = c.Write([]byte{5, 2})
+		sub := make([]byte, 2) // VER ULEN
+		if _, err := io.ReadFull(br, sub); err != nil || sub[0] != 1 {
+			return
+		}
+		user := make([]byte, sub[1])
+		if _, err := io.ReadFull(br, user); err != nil {
+			return
+		}
+		plen := make([]byte, 1)
+		if _, err := io.ReadFull(br, plen); err != nil {
+			return
+		}
+		pass := make([]byte, plen[0])
+		if _, err := io.ReadFull(br, pass); err != nil {
+			return
+		}
+		if string(user) != wantUser || string(pass) != wantPass {
+			_, _ = c.Write([]byte{1, 1}) // auth failure
+			return
+		}
+		_, _ = c.Write([]byte{1, 0})
+	} else {
+		_, _ = c.Write([]byte{5, 0}) // no auth required
+	}
+
+	// Request: VER CMD RSV ATYP DST.ADDR DST.PORT — only CONNECT (1) handled.
+	req := make([]byte, 4)
+	if _, err := io.ReadFull(br, req); err != nil || req[0] != 5 || req[1] != 1 {
+		return
+	}
+	var host string
+	switch req[3] {
+	case 1: // IPv4
+		a := make([]byte, 4)
+		if _, err := io.ReadFull(br, a); err != nil {
+			return
+		}
+		host = net.IP(a).String()
+	case 3: // domain name
+		l := make([]byte, 1)
+		if _, err := io.ReadFull(br, l); err != nil {
+			return
+		}
+		d := make([]byte, l[0])
+		if _, err := io.ReadFull(br, d); err != nil {
+			return
+		}
+		host = string(d)
+	case 4: // IPv6
+		a := make([]byte, 16)
+		if _, err := io.ReadFull(br, a); err != nil {
+			return
+		}
+		host = net.IP(a).String()
+	default:
+		return
+	}
+	pb := make([]byte, 2)
+	if _, err := io.ReadFull(br, pb); err != nil {
+		return
+	}
+	target := net.JoinHostPort(host, strconv.Itoa(int(pb[0])<<8|int(pb[1])))
+	rec.add("SOCKS5 " + target)
+
+	upstream, err := net.DialTimeout("tcp", target, 5*time.Second)
+	if err != nil {
+		_, _ = c.Write([]byte{5, 1, 0, 1, 0, 0, 0, 0, 0, 0}) // general failure
+		return
+	}
+	defer upstream.Close()
+	_, _ = c.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0}) // success, bound 0.0.0.0:0
+	// Splice from br (not c) — it may hold tunnel bytes read past the request.
+	// Half-close (not Close) upstream when the client side ends, so EOF
+	// propagates without killing the response direction.
+	go func() {
+		_, _ = io.Copy(upstream, br)
+		if cw, ok := upstream.(interface{ CloseWrite() error }); ok {
+			_ = cw.CloseWrite()
+		} else {
+			_ = upstream.Close()
+		}
+	}()
+	_, _ = io.Copy(c, upstream)
+}
+
+func TestUpstream_Tunnel_SOCKS5(t *testing.T) {
+	// Non-MITM tunnel through a socks5:// or socks5h:// upstream proxy —
+	// symmetric with the transport path, where stdlib handles both natively.
+	for _, scheme := range []string{"socks5", "socks5h"} {
+		t.Run(scheme, func(t *testing.T) {
+			ln := tunnelEchoServer(t)
+			target := ln.Addr().String()
+
+			upURL, rec := startTestSOCKS5Proxy(t, "", "")
+			upURL.Scheme = scheme
+			server := tunnelModeServer(t)
+			injectUpstreamProxy(server, upURL)
+			startTunnelModeServer(t, server)
+
+			c, br := rawConnectThroughAbox(t, server, target, http.StatusOK)
+			if _, err := c.Write([]byte("d")); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			got := make([]byte, 1)
+			if _, err := io.ReadFull(br, got); err != nil {
+				t.Fatalf("read echo: %v", err)
+			}
+			if got[0] != 'D' {
+				t.Errorf("tunnel echo = %q, want %q", got, "D")
+			}
+			if targets := rec.get(); len(targets) != 1 || targets[0] != "SOCKS5 "+target {
+				t.Errorf("socks5 proxy saw %v, want [SOCKS5 %s]", targets, target)
+			}
+		})
+	}
+}
+
+func TestUpstream_Tunnel_SOCKS5_HalfClose(t *testing.T) {
+	// Client half-close must propagate through a socks5 tunnel to the origin.
+	// x/net's socks conn hides the TCP CloseWrite (it embeds the net.Conn
+	// interface), so without socksConn the origin below — which reads to EOF
+	// before replying — would never answer and this test would time out.
+	const msg = "hello"
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		all, err := io.ReadAll(c) // blocks until client FIN arrives
+		if err != nil {
+			return
+		}
+		_, _ = io.WriteString(c, strings.ToUpper(string(all)))
+	}()
+	target := ln.Addr().String()
+
+	upURL, _ := startTestSOCKS5Proxy(t, "", "")
+	server := tunnelModeServer(t)
+	injectUpstreamProxy(server, upURL)
+	startTunnelModeServer(t, server)
+
+	c, br := rawConnectThroughAbox(t, server, target, http.StatusOK)
+	if _, err := c.Write([]byte(msg)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := c.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatalf("CloseWrite: %v", err)
+	}
+	_ = c.SetReadDeadline(time.Now().Add(5 * time.Second))
+	reply, err := io.ReadAll(br)
+	if err != nil {
+		t.Fatalf("read reply (half-close likely not propagated): %v", err)
+	}
+	if string(reply) != strings.ToUpper(msg) {
+		t.Errorf("reply = %q, want %q", reply, strings.ToUpper(msg))
+	}
+}
+
+func TestUpstream_Tunnel_SOCKS5_Auth(t *testing.T) {
+	// Userinfo on a socks5:// proxy URL must drive RFC 1929 username/password
+	// auth. The fake proxy rejects wrong credentials, so success proves the
+	// auth round-trip.
+	ln := tunnelEchoServer(t)
+	target := ln.Addr().String()
+
+	upURL, rec := startTestSOCKS5Proxy(t, "u", "p")
+	server := tunnelModeServer(t)
+	injectUpstreamProxy(server, upURL)
+	startTunnelModeServer(t, server)
+
+	c, br := rawConnectThroughAbox(t, server, target, http.StatusOK)
+	if _, err := c.Write([]byte("e")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, 1)
+	if _, err := io.ReadFull(br, got); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if got[0] != 'E' {
+		t.Errorf("tunnel echo = %q, want %q", got, "E")
+	}
+	if targets := rec.get(); len(targets) != 1 || targets[0] != "SOCKS5 "+target {
+		t.Errorf("socks5 proxy saw %v, want [SOCKS5 %s]", targets, target)
+	}
+}
+
+func TestUpstream_Tunnel_SOCKS5_BadAuth_502(t *testing.T) {
+	// Wrong credentials must fail the SOCKS handshake and surface as 502.
+	ln := tunnelEchoServer(t)
+	target := ln.Addr().String()
+
+	upURL, _ := startTestSOCKS5Proxy(t, "u", "p")
+	badURL := *upURL
+	badURL.User = url.UserPassword("u", "wrong")
+	server := tunnelModeServer(t)
+	injectUpstreamProxy(server, &badURL)
+	startTunnelModeServer(t, server)
+
+	rawConnectThroughAbox(t, server, target, http.StatusBadGateway)
+}


### PR DESCRIPTION
The goproxy removal (aa5b73b) silently dropped upstream-proxy support: goproxy's transport defaulted Proxy to http.ProxyFromEnvironment and its ConnectDial chained CONNECT through https_proxy. The custom proxy dialed origins directly on both paths, so abox behind a corporate proxy lost all internet access.

Restore both paths from a single env capture:

- Capture httpproxy.FromEnvironment().ProxyFunc() in NewServer (the stdlib func caches env in a package-level sync.Once, which breaks t.Setenv tests) and wire it into http.Transport.Proxy. Covers forwarded h1 and all post-MITM h1/h2 requests; stdlib handles socks5/socks5h and Proxy-Authorization from URL userinfo natively.
- Non-MITM CONNECT tunnels now dial via dialUpstreamTunnel: direct when no proxy applies, chained CONNECT (with basic auth, https-proxy TLS, and buffered-byte preservation) for http/https proxies, and x/net/proxy SOCKS5 (with RFC 1929 auth) for socks5/socks5h — symmetric with the transport path. The SOCKS conn is wrapped to restore CloseWrite, which x/net hides behind the net.Conn interface, so tunnel half-close still propagates. Handshakes are deadline-bounded and cancel with hijackCtx.

Allowlist and SSRF policy still apply to the requested target; the proxy hop never relaxes filtering. No behavior change when no proxy env is set.