### PR TITLE
feat(dns): default upstream to host system resolver

### DIFF
--- a/docs/abox-yaml.md
+++ b/docs/abox-yaml.md
@@ -110,7 +110,7 @@ monitor:
 | `overlay` | string | "" | Directory to copy into the VM at /tmp/abox/overlay during provisioning |
 | `allowlist` | []string | [] | Domain allowlist entries (shared by DNS and HTTP filters) |
 | `dns` | object | {} | DNS configuration (see below) |
-| `dns.upstream` | string | "8.8.8.8:53" | Upstream DNS server for allowed queries. Port defaults to 53 if not specified (e.g., "8.8.8.8" is valid). |
+| `dns.upstream` | string | host system resolver | Upstream DNS server for allowed queries. When unset, abox uses the host's system resolver from `/etc/resolv.conf` (falling back to `8.8.8.8:53` if it can't be determined). Port defaults to 53 if not specified (e.g., "8.8.8.8" is valid). |
 | `http` | object | {} | HTTP proxy configuration (see below) |
 | `http.mitm` | bool | true | Enable TLS MITM for HTTPS inspection and domain fronting protection |
 | `http.max_connections` | int | 512 | Cap on concurrent client connections to the HTTP proxy, bounding host fd/goroutine use against a runaway or hostile VM. Raise for heavy parallel workloads; keep below the host's `ulimit -n`. Existing instances without this key use the default automatically. |

--- a/internal/boxfile/boxfile_test.go
+++ b/internal/boxfile/boxfile_test.go
@@ -30,8 +30,8 @@ func TestDefaultBoxfile(t *testing.T) {
 	if box.User != "ubuntu" {
 		t.Errorf("DefaultBoxfile().User = %q, want %q", box.User, "ubuntu")
 	}
-	if box.DNS.Upstream != "8.8.8.8:53" {
-		t.Errorf("DefaultBoxfile().DNS.Upstream = %q, want %q", box.DNS.Upstream, "8.8.8.8:53")
+	if box.DNS.Upstream != "" {
+		t.Errorf("DefaultBoxfile().DNS.Upstream = %q, want %q (empty = host system resolver)", box.DNS.Upstream, "")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,9 +23,13 @@ const LibvirtImagesDir = "/var/lib/libvirt/images/abox"
 
 // Default values for new instances.
 const (
-	DefaultBase     = "ubuntu-24.04"
-	DefaultDisk     = "20G"
-	DefaultUpstream = "8.8.8.8:53"
+	DefaultBase = "ubuntu-24.04"
+	DefaultDisk = "20G"
+	// DefaultUpstream is empty, meaning "use the host's system resolver" (read
+	// from /etc/resolv.conf at daemon start). This lets instances resolve DNS on
+	// networks where public resolvers like 8.8.8.8 are unreachable. An explicit
+	// upstream (IP:port or hostname) overrides it.
+	DefaultUpstream = ""
 
 	// DefaultHTTPMaxConnections caps concurrent client connections to the HTTP
 	// filter proxy, bounding host fd/goroutine use against a hostile VM. A

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -344,8 +344,8 @@ func TestDefaultInstance(t *testing.T) {
 	if inst.Base != "ubuntu-24.04" {
 		t.Errorf("DefaultInstance().Base = %q, want %q", inst.Base, "ubuntu-24.04")
 	}
-	if inst.DNS.Upstream != "8.8.8.8:53" {
-		t.Errorf("DefaultInstance().DNS.Upstream = %q, want %q", inst.DNS.Upstream, "8.8.8.8:53")
+	if inst.DNS.Upstream != "" {
+		t.Errorf("DefaultInstance().DNS.Upstream = %q, want %q (empty = host system resolver)", inst.DNS.Upstream, "")
 	}
 	if inst.Disk != "20G" {
 		t.Errorf("DefaultInstance().Disk = %q, want %q", inst.Disk, "20G")

--- a/internal/dnsfilter/resolver.go
+++ b/internal/dnsfilter/resolver.go
@@ -1,11 +1,57 @@
 package dnsfilter
 
 import (
+	"net"
 	"sync/atomic"
 	"time"
 
 	"github.com/miekg/dns"
 )
+
+// fallbackUpstream is used when the upstream is unset and the host's system
+// resolver cannot be determined (e.g. /etc/resolv.conf is missing or empty).
+const fallbackUpstream = "8.8.8.8:53"
+
+// resolvConfPath is the file consulted to discover the host's system resolver.
+// It is a package variable so tests can point it at a fixture, and so a future
+// OS-specific implementation has a single seam to replace.
+var resolvConfPath = "/etc/resolv.conf"
+
+// systemUpstream returns the host's first configured IPv4 nameserver as
+// "ip:53", read from resolvConfPath at call time. The second return value is
+// false if the file is missing/unreadable or lists no IPv4 nameservers.
+//
+// IPv6 nameservers are skipped: the upstream validation and forwarding path
+// only support IPv4, so returning an IPv6 address would fail NewServer and
+// prevent the daemon from starting. Falling back to the public resolver is
+// preferable to a hard failure on IPv6-first hosts.
+func systemUpstream() (string, bool) {
+	cfg, err := dns.ClientConfigFromFile(resolvConfPath)
+	if err != nil {
+		return "", false
+	}
+	for _, server := range cfg.Servers {
+		// ClientConfigFromFile returns bare IPs (e.g. "127.0.0.53"); abox always
+		// forwards to port 53, matching the normalization applied elsewhere.
+		if ip := net.ParseIP(server); ip != nil && ip.To4() != nil {
+			return net.JoinHostPort(server, "53"), true
+		}
+	}
+	return "", false
+}
+
+// ResolveUpstream returns the upstream address to forward queries to. A
+// non-empty upstream is returned unchanged. An empty upstream means "use the
+// host's system resolver"; if that cannot be determined, fallback is returned.
+func ResolveUpstream(upstream, fallback string) string {
+	if upstream != "" {
+		return upstream
+	}
+	if sys, ok := systemUpstream(); ok {
+		return sys
+	}
+	return fallback
+}
 
 // Resolver is an interface for DNS resolution.
 // This abstraction enables mocking DNS queries in tests.

--- a/internal/dnsfilter/server.go
+++ b/internal/dnsfilter/server.go
@@ -45,6 +45,14 @@ type Server struct {
 
 // NewServer creates a new DNS server.
 func NewServer(filter *allowlist.Filter, upstream string, passive bool) (*Server, error) {
+	// An empty upstream means "use the host's system resolver" (read from
+	// /etc/resolv.conf at daemon start), falling back to a public resolver if
+	// that cannot be determined.
+	if upstream == "" {
+		upstream = ResolveUpstream("", fallbackUpstream)
+		logging.Debug("resolved DNS upstream from host system resolver", "upstream", upstream)
+	}
+
 	// Validate and normalize upstream DNS server format
 	normalizedUpstream, err := validation.NormalizeUpstreamDNS(upstream)
 	if err != nil {

--- a/internal/dnsfilter/server_test.go
+++ b/internal/dnsfilter/server_test.go
@@ -2,6 +2,8 @@ package dnsfilter
 
 import (
 	"net"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -40,7 +42,6 @@ func TestNewServer(t *testing.T) {
 		{"valid-passive", "8.8.8.8:53", true, false},
 		{"valid-hostname", "dns.google:53", false, false},
 		{"valid-no-port", "8.8.8.8", false, false},
-		{"empty-upstream", "", false, true},
 		{"invalid-port", "8.8.8.8:0", false, true},
 		{"invalid-port-high", "8.8.8.8:99999", false, true},
 	}
@@ -66,6 +67,56 @@ func TestNewServer(t *testing.T) {
 				t.Errorf("NewServer() IsActive() = %v, want %v", server.IsActive(), !tt.passive)
 			}
 		})
+	}
+}
+
+func TestNewServer_EmptyUpstreamResolvesSystem(t *testing.T) {
+	filter := allowlist.NewFilter()
+
+	origPath := resolvConfPath
+	t.Cleanup(func() { resolvConfPath = origPath })
+
+	// A resolv.conf with a nameserver: empty upstream resolves to that server:53.
+	withNS := filepath.Join(t.TempDir(), "resolv.conf")
+	if err := os.WriteFile(withNS, []byte("nameserver 10.0.0.53\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	resolvConfPath = withNS
+	server, err := NewServer(filter, "", false)
+	if err != nil {
+		t.Fatalf("NewServer(empty) error = %v", err)
+	}
+	if server.upstream != "10.0.0.53:53" {
+		t.Errorf("upstream = %q, want %q", server.upstream, "10.0.0.53:53")
+	}
+
+	// IPv6 nameservers are skipped in favor of the first IPv4 one, since the
+	// upstream path only supports IPv4.
+	mixed := filepath.Join(t.TempDir(), "resolv.conf")
+	if err := os.WriteFile(mixed, []byte("nameserver ::1\nnameserver 10.0.0.53\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	resolvConfPath = mixed
+	server, err = NewServer(filter, "", false)
+	if err != nil {
+		t.Fatalf("NewServer(empty, ipv6+ipv4) error = %v", err)
+	}
+	if server.upstream != "10.0.0.53:53" {
+		t.Errorf("upstream = %q, want %q (IPv6 skipped)", server.upstream, "10.0.0.53:53")
+	}
+
+	// A resolv.conf with no usable (IPv4) nameservers: empty upstream falls back.
+	noNS := filepath.Join(t.TempDir(), "resolv.conf")
+	if err := os.WriteFile(noNS, []byte("nameserver ::1\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	resolvConfPath = noNS
+	server, err = NewServer(filter, "", false)
+	if err != nil {
+		t.Fatalf("NewServer(empty, no ipv4 ns) error = %v", err)
+	}
+	if server.upstream != fallbackUpstream {
+		t.Errorf("upstream = %q, want fallback %q", server.upstream, fallbackUpstream)
 	}
 }
 

--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -99,7 +99,7 @@ as an argument (overrides the name in the file) or read from the file.`,
 	cmd.Flags().IntVarP(&opts.CPUs, "cpus", "c", 2, "Number of CPUs")
 	cmd.Flags().IntVarP(&opts.Memory, "memory", "m", 4096, "Memory in MB")
 	cmd.Flags().StringVarP(&opts.Base, "base", "b", "ubuntu-24.04", "Base image name")
-	cmd.Flags().StringVarP(&opts.Upstream, "upstream", "u", "8.8.8.8:53", "Upstream DNS server")
+	cmd.Flags().StringVarP(&opts.Upstream, "upstream", "u", "", "Upstream DNS server (default: host system resolver from /etc/resolv.conf)")
 	cmd.Flags().StringVar(&opts.Disk, "disk", "20G", "Disk size")
 	cmd.Flags().StringVar(&opts.Subnet, "subnet", "", "Subnet to use (e.g., 192.168.50.0/24)")
 	cmd.Flags().StringVar(&opts.User, "user", "", "SSH username (auto-detected from base image if not specified)")

--- a/pkg/cmd/doctor/doctor.go
+++ b/pkg/cmd/doctor/doctor.go
@@ -543,10 +543,9 @@ func checkGuestDiskSpace(paths *config.Paths, user, ip string) CheckResult {
 func checkDNSUpstream(inst *config.Instance) CheckResult {
 	result := CheckResult{Name: CheckNameDNSUpstream}
 
-	upstream := inst.DNS.Upstream
-	if upstream == "" {
-		upstream = "8.8.8.8:53"
-	}
+	// An empty upstream means "use the host's system resolver"; resolve it the
+	// same way the DNS daemon does so the check reflects real behavior.
+	upstream := dnsfilter.ResolveUpstream(inst.DNS.Upstream, "8.8.8.8:53")
 
 	// Use dig to test upstream DNS
 	cmd := exec.Command("dig", "@"+strings.Split(upstream, ":")[0], "google.com", "+short", "+time=2", "+tries=1")

--- a/pkg/cmd/helptopics/yaml.go
+++ b/pkg/cmd/helptopics/yaml.go
@@ -20,7 +20,7 @@ FIELDS
   allowlist        []string Domain allowlist entries (shared by DNS and HTTP filters)
 
   dns:                      DNS configuration object
-    upstream       string   Upstream DNS server (default: "8.8.8.8:53")
+    upstream       string   Upstream DNS server (default: host system resolver from /etc/resolv.conf)
 
   http:                     HTTP proxy configuration object
     mitm           bool     Enable TLS MITM for HTTPS inspection (default: true)

--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -327,7 +327,7 @@ func allocateResources(opts *Options, name string, manifest *export.Manifest, w 
 		Bridge:  bridge,
 		DNS: config.DNSConfig{
 			Port:     0,
-			Upstream: "8.8.8.8:53",
+			Upstream: config.DefaultUpstream,
 		},
 		SSHKey:     paths.SSHKey,
 		Disk:       manifest.Instance.Disk,

--- a/pkg/cmd/init/init.go
+++ b/pkg/cmd/init/init.go
@@ -233,7 +233,12 @@ func promptDisk(f *factory.Factory, p cmdutil.Prompter, defaultDisk string) stri
 // promptUpstreamDNS prompts for and validates the upstream DNS server.
 func promptUpstreamDNS(f *factory.Factory, p cmdutil.Prompter, defaultUpstream string) string {
 	for {
-		upstream := p.Input("Upstream DNS server", defaultUpstream)
+		upstream := p.Input("Upstream DNS server (empty = host system resolver)", defaultUpstream)
+		// An empty value means "use the host's system resolver", resolved at
+		// daemon start; accept it without validation.
+		if upstream == "" {
+			return ""
+		}
 		normalized, err := validation.NormalizeUpstreamDNS(upstream)
 		if err != nil {
 			fmt.Fprintf(f.IO.ErrOut, "  %v\n", err)

--- a/pkg/cmd/status/status.go
+++ b/pkg/cmd/status/status.go
@@ -249,7 +249,11 @@ func runStatus(opts *Options, name string) error {
 	// DNS Filter Status
 	fmt.Fprintln(w, "\n[DNS Filter]")
 	fmt.Fprintf(w, "  Port:     %d\n", inst.DNS.Port)
-	fmt.Fprintf(w, "  Upstream: %s\n", inst.DNS.Upstream)
+	if inst.DNS.Upstream == "" {
+		fmt.Fprintf(w, "  Upstream: %s (host system resolver)\n", dnsfilter.ResolveUpstream("", "8.8.8.8:53"))
+	} else {
+		fmt.Fprintf(w, "  Upstream: %s\n", inst.DNS.Upstream)
+	}
 
 	if dnsStatus != nil {
 		fmt.Fprintf(w, "  Status:   running (%s mode)\n", dnsStatus.Mode)


### PR DESCRIPTION
The DNS upstream previously defaulted to a hardcoded 8.8.8.8:53, which fails on networks where public resolvers are unreachable (e.g. air-gapped or egress-filtered environments, and our e2e host). Since the dnsfilter daemon runs on the host (VM -> gateway -> dnsfilter -> upstream), the host's own resolver is reachable and correct.

An unset/empty upstream now means "use the host's system resolver", read from /etc/resolv.conf at daemon start (via miekg/dns ClientConfigFromFile) and resolved in dnsfilter.NewServer. IPv6 nameservers are skipped since the upstream path is IPv4-only; if no IPv4 nameserver is found it falls back to 8.8.8.8:53 so the daemon still starts. An explicit upstream (IP:port or hostname) still overrides.

Existing instances with an explicit upstream in config.yaml are unchanged. Also updates create/import defaults, doctor's reachability check, the init prompt (empty now accepted), and status display to reflect the resolved upstream.