### PR TITLE
fix(monitor): detect and surface inaccessible virtio-serial socket

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -188,6 +188,23 @@ groups | grep libvirt
 
 If not in the libvirt group, abox will use pkexec or sudo for virsh commands, which may prompt for passwords.
 
+### Monitor Group Membership (when monitoring is enabled)
+
+The Tetragon monitor streams events from the VM over a virtio-serial socket that
+libvirt creates owned by qemu's group (commonly `kvm`, sometimes `libvirt-qemu` or
+`qemu` depending on your distribution and `/etc/libvirt/qemu.conf`). The monitor
+daemon runs as your user, so you must be a member of that group to read the socket —
+otherwise events are silently not captured (`EventsLogged: 0`).
+
+```bash
+# Add yourself to the socket's group (usually kvm); start a new login session after.
+sudo usermod -aG kvm $USER
+```
+
+`abox start` reports the exact group to join if you're not a member. See
+[troubleshooting](troubleshooting.md#monitor-captures-no-events) if monitoring shows
+no events.
+
 ### Polkit Configuration (Optional)
 
 To avoid password prompts when not in the libvirt group, create a polkit rule:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -335,6 +335,43 @@ This checks: host configuration, VM state, network, DNS/HTTP filter services, SS
    # Run script commands one by one
    ```
 
+### Monitor Captures No Events
+
+**Symptoms:**
+- `abox monitor logs <name>` is empty even though Tetragon is running in the VM
+- `abox monitor status <name>` shows `Events logged: 0` (with the socket reported as
+  existing and the daemon running)
+- `TestMonitorEventTypes` e2e subtests fail with "no ... event found"
+
+**Cause:**
+
+libvirt creates the monitor virtio-serial socket
+(`~/.local/share/abox/instances/<name>/monitor.sock`) owned by qemu's group (e.g.
+`libvirt-qemu:kvm`, mode `0775`). The monitor daemon runs as your user; if you are not
+a member of the socket's owning group, `connect()` fails with `permission denied` and
+the daemon retries silently, so no events are logged. (The `<permissions>` element abox
+emits in the domain XML is best-effort and is ignored for chardev sockets on most
+libvirt versions, which is why group membership is required.)
+
+**Resolution:**
+
+1. Find the socket's group and confirm you're not in it:
+   ```bash
+   ls -l ~/.local/share/abox/instances/<name>/monitor.sock   # 4th column = group
+   id                                                          # your groups
+   ```
+2. Add yourself to that group and start a **new login session** (a fresh shell is not
+   enough — the daemon inherits the login session's groups):
+   ```bash
+   sudo usermod -aG kvm "$USER"   # use the group from step 1
+   ```
+3. Restart the instance (`abox stop <name> && abox start <name>`) and confirm:
+   ```bash
+   abox monitor status <name>     # Events logged: should be > 0
+   ```
+
+`abox start` prints a warning naming the exact group when it detects this.
+
 ## Log Locations
 
 Instance data is stored at `~/.local/share/abox/instances/<name>/`.

--- a/e2e/monitor_test.go
+++ b/e2e/monitor_test.go
@@ -270,13 +270,27 @@ func TestMonitorEventTypes(t *testing.T) {
 		ti.triggerSSH(t, "sentinel-done", "touch", "/tmp/abox-sentinel-done")
 
 		deadline := time.Now().Add(15 * time.Second)
+		sentinelSeen := false
 		for time.Now().Before(deadline) {
 			if lines := monitorQuery(env, name,
 				`select(.type == "file" and .path == "/tmp/abox-sentinel-done")`); len(lines) > 0 {
 				t.Log("Pipeline sync: sentinel-done seen in monitor log")
+				sentinelSeen = true
 				break
 			}
 			time.Sleep(1 * time.Second)
+		}
+
+		// The sentinel is a touch (a default, always-on file kprobe). If it never
+		// reaches the host monitor log, the entire VM->host event pipeline is dead
+		// (e.g. the daemon can't connect to the virtio-serial socket because the
+		// invoking user isn't in the socket's group). Fail loudly here rather than
+		// letting every downstream verify-* subtest fail with cryptic empty logs.
+		if !sentinelSeen {
+			dumpMonitorDiagnostics(t, env, ti)
+			t.Fatal("monitor pipeline produced no events: sentinel-done never reached the host " +
+				"monitor log within 15s. Check that the invoking user is in the monitor socket's " +
+				"owning group (see 'abox monitor status' and the socket owner via ls -l).")
 		}
 	})
 

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -3,7 +3,9 @@ package monitor
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
 	"sync"
@@ -56,6 +58,11 @@ func ConnectWithRetry(ctx context.Context, socketPath string, interval time.Dura
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
+	// warnedPermission ensures a persistent permission error is surfaced at WARN
+	// exactly once per call (the loop never returns while EACCES persists), rather
+	// than spamming a WARN every tick.
+	warnedPermission := false
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -65,7 +72,19 @@ func ConnectWithRetry(ctx context.Context, socketPath string, interval time.Dura
 			if err == nil {
 				return mon, nil
 			}
-			logging.Debug("waiting for monitor socket", "path", socketPath, "error", err)
+			// A permission error means the socket exists but the daemon's user
+			// can't connect — almost always missing membership in the socket's
+			// owning group. Surface that loudly (once). "Not yet created" races
+			// (ENOENT) during normal boot stay at DEBUG.
+			if errors.Is(err, fs.ErrPermission) {
+				if !warnedPermission {
+					logging.Warn("monitor socket exists but is not accessible (permission denied); "+
+						"the invoking user is likely not in the socket's owning group", "path", socketPath, "error", err)
+					warnedPermission = true
+				}
+			} else {
+				logging.Debug("waiting for monitor socket", "path", socketPath, "error", err)
+			}
 		}
 	}
 }

--- a/internal/privilege/privilege.go
+++ b/internal/privilege/privilege.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 
@@ -46,7 +47,13 @@ func InGroup(groupName string) bool {
 		return false
 	}
 
-	// Check real and effective GID first.
+	return inGID(gid)
+}
+
+// inGID reports whether the current process belongs to the given GID, checking
+// the real GID, effective GID, and supplementary groups (POSIX leaves it
+// unspecified whether the real/effective GIDs appear in the supplementary list).
+func inGID(gid int) bool {
 	if os.Getgid() == gid || os.Getegid() == gid {
 		return true
 	}
@@ -57,6 +64,38 @@ func InGroup(groupName string) bool {
 	}
 
 	return slices.Contains(groups, gid)
+}
+
+// SocketGroupAccess describes a unix socket's owning group and whether the
+// current process can reach it via that group's permissions.
+type SocketGroupAccess struct {
+	Group    string // owning group name, or the numeric GID if it can't be resolved
+	GID      int
+	IsMember bool // whether the current process is a member of the owning group
+}
+
+// CheckSocketGroupAccess stats the socket at path and reports its owning group
+// and whether the current process is a member of it. This is the authoritative
+// check for whether a connect() will be permitted via group permissions — the
+// common case for libvirt-created chardev sockets, which are group-owned (e.g.
+// kvm/libvirt-qemu) rather than owned by the invoking user.
+func CheckSocketGroupAccess(path string) (SocketGroupAccess, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return SocketGroupAccess{}, err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return SocketGroupAccess{}, fmt.Errorf("cannot determine ownership of %s", path)
+	}
+
+	gid := int(stat.Gid)
+	gidStr := strconv.Itoa(gid)
+	access := SocketGroupAccess{GID: gid, Group: gidStr, IsMember: inGID(gid)}
+	if g, err := user.LookupGroupId(gidStr); err == nil {
+		access.Group = g.Name
+	}
+	return access, nil
 }
 
 // CanAccessLibvirtImages checks if the current user/process can access libvirt disk paths.

--- a/internal/privilege/privilege_test.go
+++ b/internal/privilege/privilege_test.go
@@ -1,8 +1,10 @@
 package privilege
 
 import (
+	"net"
 	"os"
 	"os/user"
+	"path/filepath"
 	"strconv"
 	"testing"
 )
@@ -47,4 +49,34 @@ func TestInGroup(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckSocketGroupAccess(t *testing.T) {
+	t.Run("missing socket returns error", func(t *testing.T) {
+		_, err := CheckSocketGroupAccess(filepath.Join(t.TempDir(), "nope.sock"))
+		if err == nil {
+			t.Fatal("expected error for nonexistent socket")
+		}
+	})
+
+	t.Run("socket owned by our group is a member", func(t *testing.T) {
+		// A socket we create is owned by our gid, so we must be reported a member.
+		sockPath := filepath.Join(t.TempDir(), "test.sock")
+		l, err := net.Listen("unix", sockPath)
+		if err != nil {
+			t.Fatalf("failed to create test socket: %v", err)
+		}
+		defer l.Close()
+
+		access, err := CheckSocketGroupAccess(sockPath)
+		if err != nil {
+			t.Fatalf("CheckSocketGroupAccess returned error: %v", err)
+		}
+		if access.GID != os.Getgid() {
+			t.Errorf("GID = %d, want %d", access.GID, os.Getgid())
+		}
+		if !access.IsMember {
+			t.Errorf("IsMember = false, want true for our own group %q (gid %d)", access.Group, access.GID)
+		}
+	})
 }

--- a/internal/privilege/privilege_test.go
+++ b/internal/privilege/privilege_test.go
@@ -66,7 +66,7 @@ func TestCheckSocketGroupAccess(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to create test socket: %v", err)
 		}
-		defer l.Close()
+		defer func() { _ = l.Close() }()
 
 		access, err := CheckSocketGroupAccess(sockPath)
 		if err != nil {

--- a/pkg/cmd/checkdeps/checkdeps.go
+++ b/pkg/cmd/checkdeps/checkdeps.go
@@ -275,6 +275,9 @@ func validateLibvirtAccess(w io.Writer, quiet bool) error {
 		} else {
 			fmt.Fprintln(w, "  libvirt images access: ok")
 		}
+		fmt.Fprintln(w, "  monitor (if enabled): also requires membership in the libvirt")
+		fmt.Fprintln(w, "    socket group (usually 'kvm' or 'libvirt-qemu', varies by distro);")
+		fmt.Fprintln(w, "    'abox start' reports the exact group if you're not a member.")
 		fmt.Fprintln(w)
 	}
 	return nil

--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sandialabs/abox/internal/instance"
 	"github.com/sandialabs/abox/internal/logging"
 	"github.com/sandialabs/abox/internal/monitor"
+	"github.com/sandialabs/abox/internal/privilege"
 	"github.com/sandialabs/abox/internal/rpc"
 	"github.com/sandialabs/abox/internal/tetragon"
 	"github.com/sandialabs/abox/pkg/cmd/completion"
@@ -163,6 +164,8 @@ func recoverDaemons(w io.Writer, name string, inst *config.Instance, paths *conf
 		if err := startMonitorDaemon(w, name, paths); err != nil {
 			return fmt.Errorf("failed to recover monitor daemon: %w", err)
 		}
+		// VM is already running, so the socket exists; warn if it's unreachable.
+		warnIfMonitorSocketInaccessible(w, paths)
 	}
 	return nil
 }
@@ -229,6 +232,12 @@ func startVMAndApplyFilter(ctx context.Context, w io.Writer, be backend.Backend,
 		return fmt.Errorf("failed to start VM: %w", err)
 	}
 
+	// The monitor socket is created by libvirt during VM start; warn now if its
+	// owning group makes it unreachable to the monitor daemon.
+	if inst.Monitor.Enabled {
+		warnIfMonitorSocketInaccessible(w, paths)
+	}
+
 	// Apply nwfilter to the running VM so traffic rules are enforced
 	if ti := be.TrafficInterceptor(); ti != nil {
 		fmt.Fprintln(w, "Applying network filter...")
@@ -281,6 +290,34 @@ func startMonitorDaemon(w io.Writer, name string, paths *config.Paths) error {
 		Socket:  paths.MonitorRPCSocket,
 		PIDFile: paths.MonitorPIDFile,
 	})
+}
+
+// warnIfMonitorSocketInaccessible warns (non-fatally) when the libvirt-created
+// monitor virtio-serial socket is owned by a group the invoking user isn't in.
+// In that case the monitor daemon silently can't connect and no events are
+// captured. libvirt creates the socket at VM start owned by qemu's group (e.g.
+// kvm/libvirt-qemu, varying by distro), so the only point we can read the real
+// group is after the VM is up. The daemon itself keeps retrying, so this is
+// purely an early, actionable heads-up.
+func warnIfMonitorSocketInaccessible(w io.Writer, paths *config.Paths) {
+	// Wait briefly for libvirt to create the socket after VM start.
+	deadline := time.Now().Add(5 * time.Second)
+	for !monitor.IsAvailable(paths.MonitorSocket) {
+		if time.Now().After(deadline) {
+			return // never appeared; the daemon's own retry/logging covers this
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	access, err := privilege.CheckSocketGroupAccess(paths.MonitorSocket)
+	if err != nil || access.IsMember {
+		return
+	}
+
+	fmt.Fprintln(w, "Warning: monitor events may not be captured.")
+	fmt.Fprintf(w, "  The monitor socket is owned by group %q, which you are not a member of,\n", access.Group)
+	fmt.Fprintln(w, "  so the monitor daemon cannot connect to it.")
+	fmt.Fprintf(w, "  Fix: sudo usermod -aG %s \"$USER\"  (then start a new login session)\n", access.Group)
 }
 
 // setupDNSResources queries dnsfilter for the actual port and updates config.


### PR DESCRIPTION
On qemu:///system hosts, libvirt creates the monitor channel socket (~/.local/share/abox/instances/<name>/monitor.sock) owned by qemu's group (e.g. libvirt-qemu:kvm, mode 0775). The monitor daemon runs as the invoking user; if that user isn't in the socket's owning group, connect() fails with EACCES and the daemon retried forever at DEBUG, so no events were ever logged (EventsLogged: 0) and every TestMonitorEventTypes verify-* subtest failed with cryptic empty logs.

libvirt has no per-domain knob to set a chardev socket's owner/group/mode (the <permissions> element abox emits is non-standard for chardev and ignored), so group membership is the supported fix. This change makes the requirement discoverable instead of failing silently:

- privilege: add CheckSocketGroupAccess, which stats the socket's actual owning gid and reports membership (authoritative, unlike InLibvirtQemuGroup which is true for any of libvirt-qemu/qemu/kvm). Refactor InGroup to share inGID.
- start: warn (non-fatally) after VM start, and on daemon recovery, naming the exact group and the usermod command when the user isn't a member.
- monitor: surface the connect permission failure at WARN (once) instead of DEBUG; ENOENT boot races stay at DEBUG.
- checkdeps: note the monitor socket-group requirement (not a RunQuiet gate).
- e2e: fail loudly with diagnostics when the sentinel event never reaches the host monitor log, instead of letting downstream subtests fail cryptically.
- docs: document the requirement and the <permissions> best-effort caveat.